### PR TITLE
fix(toolbox-core): fix config to build in the right place

### DIFF
--- a/packages/toolbox-core/jest.config.json
+++ b/packages/toolbox-core/jest.config.json
@@ -3,6 +3,14 @@
         "<rootDir>/test/*.ts"
     ],
     "preset": "ts-jest",
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.test.json"
+        }
+      ]
+    },
     "testEnvironment": "node",
     "collectCoverage": true,
     "coverageDirectory": "coverage",

--- a/packages/toolbox-core/jest.e2e.config.json
+++ b/packages/toolbox-core/jest.e2e.config.json
@@ -4,6 +4,14 @@
     "testMatch": [
         "<rootDir>/test/e2e/*.e2e.ts"
     ],
+     "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.test.json"
+        }
+      ]
+    },
     "globalSetup": "<rootDir>/test/e2e/jest.globalSetup.ts",
     "globalTeardown": "<rootDir>/test/e2e/jest.globalTeardown.ts",
     "testTimeout": 60000,

--- a/packages/toolbox-core/tsconfig.json
+++ b/packages/toolbox-core/tsconfig.json
@@ -1,15 +1,14 @@
 {
     "extends": "./node_modules/gts/tsconfig-google.json",
     "compilerOptions": {
-      "rootDir": ".",
-      "outDir": "build",
+      "rootDir": "src/toolbox_core",
+      "outDir": "build"
     },
     "include": [
-      "src/**/*.ts",
-      "test/*.ts", "test/e2e/test.e2e.ts", "test/e2e/utils.ts"
+      "src/**/*.ts"
     ],
     "exclude": [
       "node_modules",
       "build"
     ]
-  }
+}

--- a/packages/toolbox-core/tsconfig.test.json
+++ b/packages/toolbox-core/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "rootDir": ".",
+      "outDir": "build"
+    }
+}


### PR DESCRIPTION
1. This PR updates the rootDir in `tsconfig.json` to ensure the compiled output in the build directory has a flat structure. This alignment resolves module resolution errors when using the package locally via `npm link` or other tools.
2. This change refines the build process by excluding test files from the main `tsconfig.json` compilation. This ensures the final build output contains only distributable source code from the `src` directory, which is a standard best practice for library packaging.