### PR TITLE
ci: correct tag for github release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
     ],
     "packages": {
       "packages/toolbox-core": {
-        "component": "toolbox-core"
+        "component": "core"
       }
     },
     "plugins": [


### PR DESCRIPTION
For JS releases, the process of pushing the package to the registry involves looking for a github tag either matching `core-v0.1.0` or `@toolbox/core@0.1.0`.

This current config creates github tags of the form `toolbox-core-v0.1.0`.

Changed the config to create github tags of the form `core-v0.1.0` to align with the release workflow.
 