### PR TITLE
fix(toolbox-core): Simplify tool invocation response handling

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -177,9 +177,7 @@ function ToolboxTool(
           headers,
         }
       );
-      return typeof response.data === 'string'
-        ? response.data
-        : JSON.stringify(response.data);
+      return response.data.result;
     } catch (error) {
       logApiError(`Error posting data to ${toolUrl}:`, error);
       throw error;

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -354,7 +354,7 @@ describe('ToolboxClient E2E Tests', () => {
     it('should run tool with optional params omitted', async () => {
       const response = await searchRowsTool({email: 'twishabansal@google.com'});
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).toContain('row2');
       expect(response).not.toContain('row3');
@@ -369,7 +369,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row3',
       });
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).not.toContain('row2');
       expect(response).toContain('row3');
@@ -384,7 +384,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: null,
       });
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).toContain('row2');
       expect(response).not.toContain('row3');
@@ -399,7 +399,7 @@ describe('ToolboxClient E2E Tests', () => {
         id: 1,
       });
       expect(typeof response).toBe('string');
-      expect(response).toBe('{"result":"null"}');
+      expect(response).toBe('null');
     });
 
     it('should run tool with optional id as null', async () => {
@@ -408,7 +408,7 @@ describe('ToolboxClient E2E Tests', () => {
         id: null,
       });
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).toContain('row2');
       expect(response).not.toContain('row3');
@@ -438,7 +438,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row2',
       });
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).toContain('row2');
       expect(response).not.toContain('row3');
@@ -454,7 +454,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row3',
       });
       expect(typeof response).toBe('string');
-      expect(response).toContain('\\"email\\":\\"twishabansal@google.com\\"');
+      expect(response).toContain('"email":"twishabansal@google.com"');
       expect(response).not.toContain('row1');
       expect(response).not.toContain('row2');
       expect(response).toContain('row3');
@@ -470,7 +470,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row3',
       });
       expect(typeof response).toBe('string');
-      expect(response).toBe('{"result":"null"}');
+      expect(response).toBe('null');
     });
 
     it('should return null when called with different data', async () => {
@@ -480,7 +480,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row4',
       });
       expect(typeof response).toBe('string');
-      expect(response).toBe('{"result":"null"}');
+      expect(response).toBe('null');
     });
 
     it('should return null when called with a different id', async () => {
@@ -490,7 +490,7 @@ describe('ToolboxClient E2E Tests', () => {
         data: 'row3',
       });
       expect(typeof response).toBe('string');
-      expect(response).toBe('{"result":"null"}');
+      expect(response).toBe('null');
     });
   });
 });

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -307,7 +307,7 @@ describe('ToolboxTool', () => {
       expect(mockAxiosPost).toHaveBeenCalledWith(expectedUrl, validArgs, {
         headers: {},
       });
-      expect(result).toEqual(JSON.stringify(mockApiResponseData));
+      expect(result).toEqual(mockApiResponseData['result']);
     });
 
     it('should re-throw the error and log to console.error if API call fails', async () => {
@@ -421,7 +421,7 @@ describe('ToolboxTool', () => {
 
     it('should validate only the user-provided arguments, not the bound ones', async () => {
       const boundTool = tool.bindParams({query: 'a valid query'});
-      mockAxiosPost.mockResolvedValueOnce({data: 'success'});
+      mockAxiosPost.mockResolvedValueOnce({data: {result: 'success'}});
       // This call is valid because 'query' is bound, and no invalid args are passed
       await expect(boundTool()).resolves.toBe('success');
     });


### PR DESCRIPTION
# Summary
Currently, the response from a tool invocation is unnecessarily nested and improperly serialized. This results in a cryptic and hard-to-parse string, which can confuse LLMs and make debugging difficult.

# Changes

This PR adjusts the response handling logic to:

1. Directly access and return the value of the `result` key.
1. Ensure the payload is not double-stringified.

This change makes the tool output significantly more intuitive and easier for an LLM to consume directly.

> [!NOTE]
> In fact this is how Toolbox Python SDK also implements its response handling.

For example, a simple JSON object is returned as a stringified string within another JSON structure:

## Before
`{\"result\":\"[{\\\"data\\\":\\\"row2\\\"\"}`

## After
`{"data":"row2"}`