### PR TITLE
feat(core): Removes the strict duplicate header check during initialization

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -75,17 +75,6 @@ function ToolboxTool(
       'Sending ID token over HTTP. User data may be exposed. Use HTTPS for secure communication.',
     );
   }
-
-  const requestHeaderNames = Object.keys(clientHeaders);
-  const authTokenNames = Object.keys(authTokenGetters).map(getAuthHeaderName);
-  const duplicates = requestHeaderNames.filter(h => authTokenNames.includes(h));
-
-  if (duplicates.length > 0) {
-    throw new Error(
-      `Client header(s) \`${duplicates.join(', ')}\` already registered in client. Cannot register the same headers in the client as well as tool.`,
-    );
-  }
-
   const toolUrl = `${baseUrl}/api/tool/${name}/invoke`;
   const boundKeys = Object.keys(boundParams);
   const userParamSchema = paramSchema.omit(


### PR DESCRIPTION
## What does this PR do?

This PR modifies the `ToolboxTool` factory function by removing the strict error check for conflicting header names that ran during initialization.

## Why is this change needed?

The original behavior was too restrictive, throwing an error if a `clientHeader` and an `authTokenGetter` would result in the same final header name. This prevented a common use case where a specific auth token needs to take precedence over a general client header.

This change allows `authTokenGetters` to override `clientHeaders`, providing more flexibility. 
[link for strict check tool.ts](http://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/src/toolbox_core/tool.ts#L79)

