### PR TITLE
feat: Adds test case for auth token getter and client header conflict

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -76,7 +76,6 @@ function ToolboxTool(
     );
   }
 
-
   const toolUrl = `${baseUrl}/api/tool/${name}/invoke`;
   const boundKeys = Object.keys(boundParams);
   const userParamSchema = paramSchema.omit(

--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -76,15 +76,6 @@ function ToolboxTool(
     );
   }
 
-  const requestHeaderNames = Object.keys(clientHeaders);
-  const authTokenNames = Object.keys(authTokenGetters).map(getAuthHeaderName);
-  const duplicates = requestHeaderNames.filter(h => authTokenNames.includes(h));
-
-  if (duplicates.length > 0) {
-    throw new Error(
-      `Client header(s) \`${duplicates.join(', ')}\` already registered in client. Cannot register the same headers in the client as well as tool.`,
-    );
-  }
 
   const toolUrl = `${baseUrl}/api/tool/${name}/invoke`;
   const boundKeys = Object.keys(boundParams);

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -135,7 +135,6 @@ describe('ToolboxTool', () => {
         'Sending ID token over HTTP. User data may be exposed. Use HTTPS for secure communication.',
       );
     });
-
   });
 
   describe('Callable Function - Argument Validation', () => {

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ToolboxTool} from '../src/toolbox_core/tool';
+import {ToolboxTool} from '../src/toolbox_core/tool.js';
 import {z, ZodObject, ZodRawShape} from 'zod';
 import {AxiosInstance, AxiosResponse} from 'axios';
-import * as utils from '../src/toolbox_core/utils';
+import * as utils from '../src/toolbox_core/utils.js';
 
 // Global mocks
 const mockAxiosPost = jest.fn();
@@ -136,26 +136,6 @@ describe('ToolboxTool', () => {
       );
     });
 
-    it('should throw an error if client headers and auth tokens have conflicting names', () => {
-      const authTokenGetters = {service1: () => 'token'};
-      const clientHeaders = {service1_token: 'some-other-token'}; // Conflicts with service1
-      expect(() => {
-        ToolboxTool(
-          mockSession,
-          baseURL,
-          toolName,
-          toolDescription,
-          basicParamSchema,
-          authTokenGetters,
-          {},
-          [],
-          {},
-          clientHeaders,
-        );
-      }).toThrow(
-        'Client header(s) `service1_token` already registered in client. Cannot register the same headers in the client as well as tool.',
-      );
-    });
   });
 
   describe('Callable Function - Argument Validation', () => {
@@ -614,6 +594,45 @@ describe('ToolboxTool', () => {
         toolWithClientHeader.addAuthTokenGetter('service1', () => 'token'),
       ).toThrow(
         'Client header(s) `service1_token` already registered in client. Cannot register the same headers in the client as well as tool.',
+      );
+    });
+    it('should override client headers with auth token getters during API call', async () => {
+      const clientHeaders = {
+        service1_token: 'value-from-client',
+        'x-another-header': 'client-value',
+      };
+
+      const authTokenGetters = {
+        service1: () => 'value-from-auth',
+      };
+
+      const toolWithConflict = ToolboxTool(
+        mockSession,
+        baseURL,
+        toolName,
+        toolDescription,
+        basicParamSchema,
+        authTokenGetters, // Contains 'service1'
+        {},
+        [],
+        {},
+        clientHeaders, // Contains the conflicting 'service1_token'
+      );
+
+      mockAxiosPost.mockResolvedValueOnce({data: {result: 'success'}});
+
+      await toolWithConflict({query: 'test'});
+
+      // Assert that the final headers sent to the API used the value from the auth token
+      expect(mockAxiosPost).toHaveBeenCalledWith(
+        expectedUrl,
+        {query: 'test'},
+        {
+          headers: {
+            service1_token: 'value-from-auth',
+            'x-another-header': 'client-value',
+          },
+        },
       );
     });
   });


### PR DESCRIPTION
Override Behavior: A test has been added to `test.tool.ts` that specifically verifies this new behavior, ensuring that if a client header and an auth token getter have the same name, the value from the auth token getter is used during the API call [added test in test_tool.ts](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/test/test.tool.ts#L599)

Initialization Check Removal: The code block in `tool.ts` that previously prevented this override behavior at initialization has been removed, along with the corresponding test coverage. This change allows for greater flexibility in how headers are managed [ Initialization Check Removal in tool.ts ](https://github.com/googleapis/mcp-toolbox-sdk-js/blob/main/packages/toolbox-core/src/toolbox_core/tool.ts#L79)