### PR TITLE
test: improved test coverage

### DIFF
--- a/packages/toolbox-core/test/test.protocol.ts
+++ b/packages/toolbox-core/test/test.protocol.ts
@@ -497,6 +497,27 @@ describe('createZodObjectSchemaFromParameters', () => {
     });
   });
 
+  it('should handle object parameters with additionalProperties set to false', () => {
+    // This parameter definition has type: 'object' with additionalProperties: false
+    const params: ParameterSchema[] = [
+      {
+        name: 'strictObject',
+        description: 'Object with no additional properties allowed',
+        type: 'object',
+        additionalProperties: false,
+      },
+    ];
+    const schema = createZodSchemaFromParams(params);
+    expectParseSuccess(schema, {
+      strictObject: {},
+    });
+    expectParseFailure(schema, {strictObject: 'not-an-object'}, errors => {
+      expect(errors).toContain(
+        'strictObject: Expected object, received string',
+      );
+    });
+  });
+
   it('should throw an error when creating schema from parameter with unknown type', () => {
     const paramsWithUnknownType: ParameterSchema[] = [
       {

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -639,7 +639,7 @@ describe('ToolboxTool', () => {
     it('should throw an error if client header does not resolve to a string', async () => {
       const clientHeaders: ClientHeadersConfig = {
         'X-Valid-Header': 'valid-string',
-        'X-Invalid-Header': (() => 123) as unknown as () => string, 
+        'X-Invalid-Header': (() => 123) as unknown as () => string,
       };
 
       const toolWithBadHeader = ToolboxTool(

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -634,5 +634,30 @@ describe('ToolboxTool', () => {
         },
       );
     });
+
+    it('should throw an error if client header does not resolve to a string', async () => {
+      const clientHeaders = {
+        'X-Valid-Header': 'valid-string',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'X-Invalid-Header': (() => 123) as any, // This will resolve to a number, not a string
+      };
+
+      const toolWithBadHeader = ToolboxTool(
+        mockSession,
+        baseURL,
+        toolName,
+        toolDescription,
+        basicParamSchema,
+        {},
+        {},
+        [],
+        {},
+        clientHeaders,
+      );
+
+      await expect(toolWithBadHeader({query: 'test'})).rejects.toThrow(
+        "Client header 'X-Invalid-Header' did not resolve to a string.",
+      );
+    });
   });
 });

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -16,6 +16,7 @@ import {ToolboxTool} from '../src/toolbox_core/tool.js';
 import {z, ZodObject, ZodRawShape} from 'zod';
 import {AxiosInstance, AxiosResponse} from 'axios';
 import * as utils from '../src/toolbox_core/utils.js';
+import {ClientHeadersConfig} from '../src/toolbox_core/client.js';
 
 // Global mocks
 const mockAxiosPost = jest.fn();
@@ -636,10 +637,9 @@ describe('ToolboxTool', () => {
     });
 
     it('should throw an error if client header does not resolve to a string', async () => {
-      const clientHeaders = {
+      const clientHeaders: ClientHeadersConfig = {
         'X-Valid-Header': 'valid-string',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        'X-Invalid-Header': (() => 123) as any, // This will resolve to a number, not a string
+        'X-Invalid-Header': (() => 123) as unknown as () => string, 
       };
 
       const toolWithBadHeader = ToolboxTool(


### PR DESCRIPTION
Implemented test coverage for the JS SDK with a 90% threshold. Initial tests showed  toolbox-core Branch as (88.11%) which was below target. After adding new test cases, all modules now exceed the requirement.

Prev Stats:

statements: 98.92%
Branch: 88.11%
Function: 97.67%
Lines: 99.26%
New Stats:

statements: 99.64%
Branch: 95.8%
Function: 97.67%
Lines: 100%


PR for Coverage test: https://github.com/googleapis/mcp-toolbox-sdk-js/pull/108