### PR TITLE
fix(dependency): add dependabot.yml to configure dependabot for disabling version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,2 @@
-// Copyright 2025 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 version: 2
 updates: [] # This empty array disables Dependabot version updates


### PR DESCRIPTION
## Description

This PR introduces a .github/dependabot.yml file to disable Dependabot's Version Updates feature.

### Problem:

Currently, both Renovate (configured via renovate.json) and Dependabot are attempting to manage dependency version updates. This results in duplicate Pull Requests for the same updates (e.g., #169, #170, #179 for @modelcontextprotocol/sdk), causing confusion and extra review overhead.

### Goal:

To align with best practices, we want to have a clear separation of concerns:

- Renovate: Handles proactive dependency version updates.
- Dependabot: Focuses exclusively on updates for dependencies with known security vulnerabilities.
Solution:

This PR adds a .github/dependabot.yml file with the following content:


```
version: 2
updates: []
```
According to the Dependabot documentation, providing an empty updates array ([]) instructs Dependabot to not perform any version updates for any package ecosystems in this repository.

### Expected Outcome:

Renovate will continue to open PRs for dependency version updates as configured in renovate.json.
Dependabot will NO LONGER open PRs for version updates.
Dependabot will CONTINUE to open PRs for security vulnerabilities.
This change should eliminate the duplicate PRs and streamline our dependency update process.