### PR TITLE
chore: decouple release configuration for packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,13 +22,5 @@
         "component": "adk"
       }
     },
-    "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "toolbox-js-sdks",
-      "components": [
-        "core", "adk"
-      ]
-    }
-  ]
+    "separate-pull-requests": true
 }


### PR DESCRIPTION
Similar to https://github.com/googleapis/mcp-toolbox-sdk-python/pull/515

Updates the `release-please` configuration to allow packages to be released independently of each other.

Future releases will track versions independently based on changes within each package's directory.

> [!NOTE]
> This change does *not* modify the current versions in `.release-please-manifest.json`, but subsequent releases will diverge.