### PR TITLE
fix(adk): correct ESM build output directory and package exports

### DIFF
--- a/packages/toolbox-adk/package.json
+++ b/packages/toolbox-adk/package.json
@@ -17,9 +17,9 @@
     ],
     "exports": {
         ".": {
-            "import": "./build/index.js",
+            "import": "./build/esm/index.js",
             "require": "./build/cjs/index.js",
-            "types": "./build/index.d.ts"
+            "types": "./build/esm/index.d.ts"
         }
     },
     "files": [

--- a/packages/toolbox-adk/tsconfig.esm.json
+++ b/packages/toolbox-adk/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src/toolbox_adk",
-    "outDir": "build"
+    "outDir": "build/esm"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR fixes the ESM build configuration for the @toolbox-sdk/adk package to ensure correct module resolution.

Changes
- packages/toolbox-adk/tsconfig.esm.json : Updated outDir to build/esm to prevent build output conflicts and ensure a clean directory structure.
- packages/toolbox-adk/package.json: Updated the exports field for import and types to point to the correct ./build/esm/ paths, aligning with the updated TypeScript configuration.

This ensures that consumers using ESM correctly resolve the package files.

