### PR TITLE
chore: Add changelog for ADK package + fix shields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Please refer to each API's `CHANGELOG.md` file under the `packages/` directory
 
 Changelogs
 -----
-#### TODO: Add Toolbox-core version image
 | Package    | Version |
 | -------- | ------- |
-| [@toolbox-sdk/core](https://github.com/googleapis/mcp-toolbox-sdk-js/tree/main/packages/toolbox-core/CHANGELOG.md)  | ![@toolbox-sdk/core version]()    |
+| [@toolbox-sdk/core](https://github.com/googleapis/mcp-toolbox-sdk-js/tree/main/packages/toolbox-core/CHANGELOG.md)  | ![@toolbox-sdk/core version](https://img.shields.io/npm/v/%40toolbox-sdk%2Fcore)    |
+| [@toolbox-sdk/adk](https://github.com/googleapis/mcp-toolbox-sdk-js/tree/main/packages/toolbox-adk/CHANGELOG.md)  | ![@toolbox-sdk/adk version](https://img.shields.io/npm/v/%40toolbox-sdk%2Fadk)    |


### PR DESCRIPTION
This PR adds `toolbox-adk` package to the top-level `CHANGELOG.md` and fixes shield images for the existing core package.