### PR TITLE
fix(core): add 'number' schema type mapping to fix float parameter loading

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -177,6 +177,7 @@ export abstract class McpHttpTransportBase implements ITransport {
             | 'string'
             | 'integer'
             | 'float'
+            | 'number'
             | 'boolean',
         } as PrimitiveTypeSchema;
       } else {
@@ -193,6 +194,7 @@ export abstract class McpHttpTransportBase implements ITransport {
           | 'string'
           | 'integer'
           | 'float'
+          | 'number'
           | 'boolean'
           | undefined,
       } as PrimitiveTypeSchema;

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -43,6 +43,9 @@ interface IntegerType {
 interface FloatType {
   type: 'float';
 }
+interface NumberType {
+  type: 'number';
+}
 interface BooleanType {
   type: 'boolean';
 }
@@ -51,6 +54,7 @@ export type PrimitiveTypeSchema =
   | StringType
   | IntegerType
   | FloatType
+  | NumberType
   | BooleanType;
 
 interface ArrayType {
@@ -81,6 +85,7 @@ const ZodPrimitiveTypeSchema: z.ZodType<PrimitiveTypeSchema> =
     z.object({type: z.literal('string')}),
     z.object({type: z.literal('integer')}),
     z.object({type: z.literal('float')}),
+    z.object({type: z.literal('number')}),
     z.object({type: z.literal('boolean')}),
   ]);
 
@@ -90,6 +95,7 @@ const ZodTypeSchema: z.ZodType<TypeSchema> = z.lazy(() =>
     z.object({type: z.literal('string')}),
     z.object({type: z.literal('integer')}),
     z.object({type: z.literal('float')}),
+    z.object({type: z.literal('number')}),
     z.object({type: z.literal('boolean')}),
     z.object({type: z.literal('array'), items: ZodTypeSchema.optional()}),
     z.object({
@@ -136,6 +142,7 @@ function buildZodShapeFromTypeSchema(typeSchema: TypeSchema): ZodTypeAny {
     case 'integer':
       return z.number().int();
     case 'float':
+    case 'number':
       return z.number();
     case 'boolean':
       return z.boolean();

--- a/packages/toolbox-core/test/test.protocol.ts
+++ b/packages/toolbox-core/test/test.protocol.ts
@@ -80,6 +80,10 @@ describe('ZodParameterSchema', () => {
       data: {name: 'testFloat', description: 'A float', type: 'float'},
     },
     {
+      description: 'correct number parameter',
+      data: {name: 'testNumber', description: 'A number', type: 'number'},
+    },
+    {
       description: 'correct boolean parameter',
       data: {name: 'testBool', description: 'A boolean', type: 'boolean'},
     },


### PR DESCRIPTION
## Description

This PR adds support for the standard JSON Schema `'number'` type to the client validator and parser schemas.

## Context

Following the server's correction to emit standard `'type': 'number'` for floating-point parameters in MCP manifests, the client rejected tool manifests containing float parameters during Zod schema validation.

## Changes

* Declares the `NumberType` interface and includes `'number'` in Zod discriminated unions (`ZodPrimitiveTypeSchema` and `ZodTypeSchema`).
* Maps standard `'number'` to `z.number()` in the `buildZodShapeFromTypeSchema` parser.
* Maps `'number'` type assertions in the MCP `_convertTypeSchema` transport parser.
* Retains `'float'` support throughout for full backward compatibility with legacy native configs.
* Adds a replication unit test case for `'number'`.

## Checklist
- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [ ] Appropriate docs were updated (N/A - Docs are already correct)
- [ ] Make sure to add `!` if this involves a breaking change (N/A - Backward-compatible fix)

## Issue Reference

Fixes https://github.com/googleapis/mcp-toolbox-sdk-python/issues/649 🦕
