### PR TITLE
chore(renovate): auto-bump locked version of @google/adk

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,11 @@
   dependencyDashboardLabels: ["type: process"],
   packageRules: [
     {
+      description: "Bump only the locked version of @google/adk; leave the declared range untouched",
+      matchPackageNames: ["@google/adk"],
+      rangeStrategy: "update-lockfile",
+    },
+    {
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
       pinDigests: true,


### PR DESCRIPTION
## Summary
- Renovate will now open lockfile-only PRs (e.g. 1.1.0 -> 1.2.0) for `@google/adk`, the same way transitive deps like `@grpc/grpc-js` are handled (see #372).

## Why
`@google/adk` is a direct dependency declared as `^1.0.0`. The global `:preserveSemverRanges` preset (`rangeStrategy: "replace"`) suppresses PRs for in-range updates, since the new version already satisfies the range. This rule tells Renovate to bump the locked version in `package-lock.json` while leaving the declared `^1.0.0` range untouched.