### PR TITLE
fix: give ToolboxTool a named return type

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -141,7 +141,7 @@ class ToolboxClient {
    * @param {string} toolName - The name of the tool.
    * @param {ToolSchemaFromManifest} toolSchema - The schema definition of the tool from the manifest.
    * @param {BoundParams} [boundParams] - A map of all candidate parameters to bind.
-   * @returns {ReturnType<typeof ToolboxTool>} A ToolboxTool function.
+   * @returns {ToolboxTool} A ToolboxTool function.
    */
   #createToolInstance(
     toolName: string,
@@ -149,7 +149,7 @@ class ToolboxClient {
     authTokenGetters: AuthTokenGetters = {},
     boundParams: BoundParams = {},
   ): {
-    tool: ReturnType<typeof ToolboxTool>;
+    tool: ToolboxTool;
     usedAuthKeys: Set<string>;
     usedBoundKeys: Set<string>;
   } {
@@ -202,7 +202,7 @@ class ToolboxClient {
    * @param {string} name - The unique name or identifier of the tool to load.
    * @param {AuthTokenGetters | null} [authTokenGetters] - Optional map of auth service names to token getters.
    * @param {BoundParams | null} [boundParams] - Optional parameters to pre-bind to the tool.
-   * @returns {Promise<ReturnType<typeof ToolboxTool>>} A promise that resolves
+   * @returns {Promise<ToolboxTool>} A promise that resolves
    * to a ToolboxTool function, ready for execution.
    * @throws {Error} If the tool is not found in the manifest, the manifest structure is invalid,
    * or if there's an error fetching data from the API.
@@ -211,7 +211,7 @@ class ToolboxClient {
     name: string,
     authTokenGetters: AuthTokenGetters | null = {},
     boundParams: BoundParams | null = {},
-  ): Promise<ReturnType<typeof ToolboxTool>> {
+  ): Promise<ToolboxTool> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const headers = await this.#resolveClientHeaders();
     const manifest = await this.#transport.toolGet(name, headers);
@@ -271,7 +271,7 @@ class ToolboxClient {
    * @param {AuthTokenGetters | null} [authTokenGetters] - Optional map of auth service names to token getters.
    * @param {BoundParams | null} [boundParams] - Optional parameters to pre-bind to the tools in the toolset.
    * @param {boolean} [strict=false] - If true, throws an error if any provided auth token or bound param is not used by at least one tool.
-   * @returns {Promise<Array<ReturnType<typeof ToolboxTool>>>} A promise that resolves
+   * @returns {Promise<ToolboxTool[]>} A promise that resolves
    * to a list of ToolboxTool functions, ready for execution.
    * @throws {Error} If the manifest structure is invalid or if there's an error fetching data from the API.
    */
@@ -280,13 +280,13 @@ class ToolboxClient {
     authTokenGetters: AuthTokenGetters | null = {},
     boundParams: BoundParams | null = {},
     strict = false,
-  ): Promise<Array<ReturnType<typeof ToolboxTool>>> {
+  ): Promise<ToolboxTool[]> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const toolsetName = name || '';
     const headers = await this.#resolveClientHeaders();
 
     const manifest = await this.#transport.toolsList(toolsetName, headers);
-    const tools: Array<ReturnType<typeof ToolboxTool>> = [];
+    const tools: ToolboxTool[] = [];
 
     const overallUsedAuthKeys: Set<string> = new Set();
     const overallUsedBoundParams: Set<string> = new Set();

--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -29,6 +29,30 @@ export type AuthTokenGetters = Record<string, AuthTokenGetter>;
 export type RequiredAuthnParams = Record<string, string[]>;
 
 /**
+ * A loaded, callable tool. Invoke it with an arguments object to run the tool on
+ * the remote Toolbox server. The attached methods return new ToolboxTool
+ * instances with additional auth-token getters or pre-bound parameters.
+ */
+export interface ToolboxTool {
+  (callArguments?: Record<string, unknown>): Promise<string>;
+  toolName: string;
+  description: string;
+  params: ZodObject<ZodRawShape>;
+  boundParams: BoundParams;
+  authTokenGetters: AuthTokenGetters;
+  requiredAuthnParams: RequiredAuthnParams;
+  requiredAuthzTokens: string[];
+  clientHeaders: ClientHeadersConfig;
+  getName(): string;
+  getDescription(): string;
+  getParamSchema(): ZodObject<ZodRawShape>;
+  addAuthTokenGetters(newAuthTokenGetters: AuthTokenGetters): ToolboxTool;
+  addAuthTokenGetter(authSource: string, getIdToken: AuthTokenGetter): ToolboxTool;
+  bindParams(paramsToBind: BoundParams): ToolboxTool;
+  bindParam(paramName: string, paramValue: BoundValue): ToolboxTool;
+}
+
+/**
  * A helper function to get the formatted auth token header name.
  * @param {string} authTokenName - The name of the authentication service.
  * @returns {string} The formatted header name.
@@ -50,10 +74,10 @@ function getAuthHeaderName(authTokenName: string): string {
  * @param {string[]} [requiredAuthzTokens] - Optional list of auth tokens that still need satisfying.
  * @param {BoundParams} [boundParams] - Optional parameters to pre-bind to the tool.
  * @param {ClientHeadersConfig} [clientHeaders] - Optional client-specific headers.
- * @returns {CallableTool & CallableToolProperties} An async function that, when
+ * @returns {ToolboxTool} An async function that, when
  * called, invokes the tool with the provided arguments.
  */
-function ToolboxTool(
+export function ToolboxTool(
   transport: ITransport,
   name: string,
   description: string,
@@ -63,7 +87,7 @@ function ToolboxTool(
   requiredAuthzTokens: string[] = [],
   boundParams: BoundParams = {},
   clientHeaders: ClientHeadersConfig = {},
-) {
+): ToolboxTool {
   const boundKeys = Object.keys(boundParams);
   const userParamSchema = paramSchema.omit(
     Object.fromEntries(boundKeys.map(k => [k, true])),
@@ -271,7 +295,5 @@ function ToolboxTool(
   callable.bindParam = function (paramName: string, paramValue: BoundValue) {
     return this.bindParams({[paramName]: paramValue});
   };
-  return callable;
+  return callable as unknown as ToolboxTool;
 }
-
-export {ToolboxTool};

--- a/packages/toolbox-core/src/toolbox_core/tool.ts
+++ b/packages/toolbox-core/src/toolbox_core/tool.ts
@@ -47,7 +47,10 @@ export interface ToolboxTool {
   getDescription(): string;
   getParamSchema(): ZodObject<ZodRawShape>;
   addAuthTokenGetters(newAuthTokenGetters: AuthTokenGetters): ToolboxTool;
-  addAuthTokenGetter(authSource: string, getIdToken: AuthTokenGetter): ToolboxTool;
+  addAuthTokenGetter(
+    authSource: string,
+    getIdToken: AuthTokenGetter,
+  ): ToolboxTool;
   bindParams(paramsToBind: BoundParams): ToolboxTool;
   bindParam(paramName: string, paramValue: BoundValue): ToolboxTool;
 }


### PR DESCRIPTION
- The `ToolboxTool` factory had no named return type, so callers and tooling saw an inferred ~16-property anonymous object wherever a tool was returned, and its JSDoc referenced types that don't exist (`CallableTool & CallableToolProperties`).
- Net effect: a clean named type on the public surface (better autocomplete and API-reference rendering) with no runtime or public-API change.