### PR TITLE
test: trigger api-docs workflow (do not merge)

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -15,6 +15,8 @@
 
 name: "API Reference Deployment"
 on:
+  # TEMP (do not merge): lets a draft PR trigger this workflow for a real run.
+  pull_request:
   push:
     branches: [ 'main' ]
     tags: [ '**' ]


### PR DESCRIPTION
**Do not merge / do not review.** Throwaway PR to exercise the `api-docs.yml`
deploy workflow from #379 on real runners.

Temporarily adds a `pull_request:` trigger to `.github/workflows/api-docs.yml`
(the only change). The workflow otherwise has no PR trigger, so this is the
only way to run it pre-merge.

Expected on this PR run:
- Resolver hits the default case (`GITHUB_REF` = `refs/pull/N/merge`) → builds
  `core` + `adk` as `dev`.
- Root-page step is skipped (not a tag).
- Deploy step pushes the built `dev` docs to the `gh-pages` branch.

Revert the temp trigger and close this PR once the run is confirmed.