### PR TITLE
feat(core): implement support for Stateless MCP (SEP-2575)

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -27,6 +27,8 @@ import {McpHttpTransportV20241105} from './mcp/v20241105/mcp.js';
 import {McpHttpTransportV20250618} from './mcp/v20250618/mcp.js';
 import {McpHttpTransportV20250326} from './mcp/v20250326/mcp.js';
 import {McpHttpTransportV20251125} from './mcp/v20251125/mcp.js';
+import {McpHttpTransportV20260618} from './mcp/v20260618/mcp.js';
+import {ProtocolNegotiationError} from './errorUtils.js';
 import {
   BoundParams,
   identifyAuthRequirements,
@@ -49,6 +51,8 @@ export type ClientHeadersConfig = Record<string, ClientHeaderProvider>;
 class ToolboxClient {
   #transport: ITransport;
   #clientHeaders: ClientHeadersConfig;
+  #session: AxiosInstance | undefined;
+  #baseUrl: string;
 
   /**
    * Initializes the ToolboxClient.
@@ -68,7 +72,9 @@ class ToolboxClient {
     clientName?: string,
     clientVersion?: string,
   ) {
+    this.#baseUrl = url;
     this.#clientHeaders = clientHeaders || {};
+    this.#session = session || undefined;
     warnIfHttpAndHeaders(url, this.#clientHeaders);
     if (!getSupportedMcpVersions().includes(protocol)) {
       throw new Error(`Unsupported protocol version: ${protocol}`);
@@ -80,43 +86,63 @@ class ToolboxClient {
       );
     }
 
+    this.#transport = this.#createTransport(
+      url,
+      session || undefined,
+      protocol,
+      clientName,
+      clientVersion,
+    );
+  }
+
+  #createTransport(
+    url: string,
+    session: AxiosInstance | undefined,
+    protocol: Protocol,
+    clientName?: string,
+    clientVersion?: string,
+  ): ITransport {
     switch (protocol) {
       case Protocol.MCP_v20241105:
-        this.#transport = new McpHttpTransportV20241105(
+        return new McpHttpTransportV20241105(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20250326:
-        this.#transport = new McpHttpTransportV20250326(
+        return new McpHttpTransportV20250326(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20250618:
-        this.#transport = new McpHttpTransportV20250618(
+        return new McpHttpTransportV20250618(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20251125:
-        this.#transport = new McpHttpTransportV20251125(
+        return new McpHttpTransportV20251125(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
+      case Protocol.MCP_DRAFT_2026_v1:
+        return new McpHttpTransportV20260618(
+          url,
+          session,
+          protocol,
+          clientName,
+          clientVersion,
+        );
       default:
         throw new Error(`Unsupported MCP protocol version: ${protocol}`);
     }
@@ -214,7 +240,21 @@ class ToolboxClient {
   ): Promise<ToolboxTool> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const headers = await this.#resolveClientHeaders();
-    const manifest = await this.#transport.toolGet(name, headers);
+    let manifest;
+    try {
+      manifest = await this.#transport.toolGet(name, headers);
+    } catch (e: unknown) {
+      if (e instanceof ProtocolNegotiationError) {
+        this.#transport = this.#createTransport(
+          this.#baseUrl,
+          this.#session,
+          e.fallbackVersion,
+        );
+        manifest = await this.#transport.toolGet(name, headers);
+      } else {
+        throw e;
+      }
+    }
 
     if (
       manifest.tools &&
@@ -285,7 +325,21 @@ class ToolboxClient {
     const toolsetName = name || '';
     const headers = await this.#resolveClientHeaders();
 
-    const manifest = await this.#transport.toolsList(toolsetName, headers);
+    let manifest;
+    try {
+      manifest = await this.#transport.toolsList(toolsetName, headers);
+    } catch (e: unknown) {
+      if (e instanceof ProtocolNegotiationError) {
+        this.#transport = this.#createTransport(
+          this.#baseUrl,
+          this.#session,
+          e.fallbackVersion,
+        );
+        manifest = await this.#transport.toolsList(toolsetName, headers);
+      } else {
+        throw e;
+      }
+    }
     const tools: ToolboxTool[] = [];
 
     const overallUsedAuthKeys: Set<string> = new Set();

--- a/packages/toolbox-core/src/toolbox_core/errorUtils.ts
+++ b/packages/toolbox-core/src/toolbox_core/errorUtils.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {isAxiosError} from 'axios';
+import {Protocol} from './protocol.js';
 
 /**
  * Logs a standardized error message to the console, differentiating between
@@ -39,4 +40,14 @@ export function logApiError(baseMessage: string, error: unknown): void {
     loggableDetails = error; // Fallback for non-Error types or unknown errors
   }
   console.error(baseMessage, loggableDetails);
+}
+
+export class ProtocolNegotiationError extends Error {
+  fallbackVersion: Protocol;
+
+  constructor(fallbackVersion: Protocol) {
+    super(`Server requires protocol fallback to ${fallbackVersion}`);
+    this.name = 'ProtocolNegotiationError';
+    this.fallbackVersion = fallbackVersion;
+  }
 }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -51,7 +51,7 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
       };
     }
 
-    // Inject Protocol Version into headers (v2025-06-18 specific)
+    // Inject Protocol Version into headers as required by MCP spec
     const reqHeaders = {...(headers || {})};
     reqHeaders['MCP-Protocol-Version'] = this._protocolVersion;
 

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -16,14 +16,91 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../protocol.js';
 import {logApiError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
-export class McpHttpTransportV20251125 extends McpHttpTransportBase {
+import {ProtocolNegotiationError} from '../../errorUtils.js';
+
+export class McpHttpTransportV20260618 extends McpHttpTransportBase {
+  #getMeta() {
+    return {
+      protocolVersion: this._protocolVersion,
+      clientInfo: {
+        name: this._clientName || 'toolbox-core-js',
+        version: this._clientVersion || VERSION,
+      },
+      clientCapabilities: {},
+    };
+  }
+
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      (errVal as Record<string, unknown>).code === -32022
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported = getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0]);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const isLegacyError =
+      (typeof errVal === 'string' &&
+        (errVal.toLowerCase().includes('invalid protocol version') ||
+          errVal.toLowerCase().includes('unsupported protocol version'))) ||
+      (typeof errVal === 'object' &&
+        errVal !== null &&
+        'message' in errVal &&
+        (String((errVal as Record<string, unknown>).message)
+          .toLowerCase()
+          .includes('invalid protocol version') ||
+          String((errVal as Record<string, unknown>).message)
+            .toLowerCase()
+            .includes('unsupported protocol version')));
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported = getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(clientSupported[currentIdx + 1]);
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -77,7 +154,10 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -109,60 +189,21 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       return null;
     } catch (error) {
+      if (error instanceof AxiosError) {
+        const jsonResp = error.response?.data;
+        if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
+          const errVal = (jsonResp as Record<string, unknown>).error;
+          this.#checkProtocolNegotiationError(errVal);
+        }
+      }
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }
   }
 
-  protected async initializeSession(
-    headers?: Record<string, string>,
-  ): Promise<void> {
-    const params: types.InitializeRequestParams = {
-      protocolVersion: this._protocolVersion,
-      capabilities: {},
-      clientInfo: {
-        name: this._clientName || 'toolbox-core-js',
-        version: this._clientVersion || VERSION,
-      },
-    };
-
-    const result = await this.#sendRequest(
-      this._mcpBaseUrl,
-      types.InitializeRequest,
-      params,
-      headers,
-    );
-
-    if (!result) {
-      const error = new Error('Initialization failed: No response');
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    this._serverVersion = result.serverInfo.version;
-
-    if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    if (!result.capabilities.tools) {
-      const error = new Error(
-        "Server does not support the 'tools' capability.",
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    await this.#sendRequest(
-      this._mcpBaseUrl,
-      types.InitializedNotification,
-      {},
-      headers,
-    );
+  protected async initializeSession(): Promise<void> {
+    // Stateless MCP does not use initialize handshake
+    this._serverVersion = 'unknown';
   }
 
   async toolsList(
@@ -175,19 +216,13 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     const result = await this.#sendRequest(
       url,
       types.ListToolsRequest,
-      {},
+      {_meta: this.#getMeta()},
       headers,
     );
 
     if (!result) {
       const error = new Error('Failed to list tools: No response from server.');
       logApiError(`Error listing tools from ${url}`, error);
-      throw error;
-    }
-
-    if (this._serverVersion === null) {
-      const error = new Error('Server version not available.');
-      logApiError('Error listing tools', error);
       throw error;
     }
 
@@ -205,8 +240,8 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     }
 
     return {
-      serverVersion: this._serverVersion,
-      tools: toolsMap as unknown as ZodManifest['tools'], // Cast to verify structure compliance or rely on structural typing
+      serverVersion: this._serverVersion ?? 'unknown',
+      tools: toolsMap as unknown as ZodManifest['tools'],
     };
   }
 
@@ -236,13 +271,14 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
   ): Promise<string> {
     await this.ensureInitialized(headers);
 
-    if (Object.keys(headers).length > 0) {
+    if (headers && Object.keys(headers).length > 0) {
       warnIfHttpAndHeaders(this._mcpBaseUrl, headers);
     }
 
-    const params: types.CallToolRequestParams = {
+    const params = {
       name: toolName,
       arguments: arguments_,
+      _meta: this.#getMeta(),
     };
 
     const result = await this.#sendRequest(

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/types.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/types.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+
+export const RequestParamsSchema = z.object({}).passthrough();
+export type RequestParams = z.infer<typeof RequestParamsSchema>;
+
+export const JSONRPCRequestSchema = z.object({
+  jsonrpc: z.literal('2.0').default('2.0'),
+  id: z.union([z.string(), z.number()]).optional(), // Default handled in usage, or logic
+  method: z.string(),
+  params: z.record(z.unknown()).optional().nullable(),
+});
+export type JSONRPCRequest = z.infer<typeof JSONRPCRequestSchema>;
+
+export const JSONRPCNotificationSchema = z.object({
+  jsonrpc: z.literal('2.0').default('2.0'),
+  method: z.string(),
+  params: z.record(z.unknown()).optional().nullable(),
+});
+export type JSONRPCNotification = z.infer<typeof JSONRPCNotificationSchema>;
+
+export const JSONRPCResponseSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]),
+  result: z.record(z.unknown()),
+});
+export type JSONRPCResponse = z.infer<typeof JSONRPCResponseSchema>;
+
+export const ErrorDataSchema = z.object({
+  code: z.number().int(),
+  message: z.string(),
+  data: z.unknown().optional().nullable(),
+});
+export type ErrorData = z.infer<typeof ErrorDataSchema>;
+
+export const JSONRPCErrorSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]),
+  error: ErrorDataSchema,
+});
+export type JSONRPCError = z.infer<typeof JSONRPCErrorSchema>;
+
+export const BaseMetadataSchema = z
+  .object({
+    name: z.string(),
+  })
+  .passthrough();
+export type BaseMetadata = z.infer<typeof BaseMetadataSchema>;
+
+export const ToolSchema = BaseMetadataSchema.extend({
+  description: z.string().optional().nullable(),
+  inputSchema: z.record(z.unknown()),
+});
+
+export type Tool = z.infer<typeof ToolSchema>;
+
+export const ListToolsResultSchema = z.object({
+  tools: z.array(ToolSchema),
+});
+export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
+
+export const TextContentSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+export type TextContent = z.infer<typeof TextContentSchema>;
+
+export const CallToolResultSchema = z.object({
+  content: z.array(TextContentSchema),
+  isError: z.boolean().default(false).optional(),
+});
+export type CallToolResult = z.infer<typeof CallToolResultSchema>;
+
+// Generic Request/Notification types for internal usage (not full schemas)
+export type MCPRequest<T> = {
+  method: string;
+  params?: Record<string, unknown> | unknown | null;
+  getResultModel: () => z.ZodType<T>;
+};
+
+export type MCPNotification = {
+  method: string;
+  params?: Record<string, unknown> | unknown | null;
+};
+
+// Request/Notification Classes/Factories
+
+export const ListToolsRequest: MCPRequest<ListToolsResult> = {
+  method: 'tools/list',
+  params: {},
+  getResultModel: () => ListToolsResultSchema,
+};
+
+export const CallToolRequestParamsSchema = z.object({
+  name: z.string(),
+  arguments: z.record(z.unknown()),
+});
+export type CallToolRequestParams = z.infer<typeof CallToolRequestParamsSchema>;
+
+export const CallToolRequest: MCPRequest<CallToolResult> = {
+  method: 'tools/call',
+  // params computed at runtime
+  getResultModel: () => CallToolResultSchema,
+};

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -15,6 +15,7 @@
 import {z, ZodRawShape, ZodTypeAny, ZodObject} from 'zod';
 
 export enum Protocol {
+  MCP_DRAFT_2026_v1 = 'DRAFT-2026-v1',
   MCP_v20241105 = '2024-11-05',
   MCP_v20250326 = '2025-03-26',
   MCP_v20250618 = '2025-06-18',
@@ -22,14 +23,15 @@ export enum Protocol {
   MCP = MCP_v20250618, // Default MCP
 }
 
-export const MCP_LATEST = Protocol.MCP_v20251125;
+export const MCP_LATEST = Protocol.MCP_DRAFT_2026_v1;
 
 export function getSupportedMcpVersions(): Protocol[] {
   return [
-    Protocol.MCP_v20241105,
-    Protocol.MCP_v20250326,
-    Protocol.MCP_v20250618,
+    Protocol.MCP_DRAFT_2026_v1,
     Protocol.MCP_v20251125,
+    Protocol.MCP_v20250618,
+    Protocol.MCP_v20250326,
+    Protocol.MCP_v20241105,
   ];
 }
 

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -14,7 +14,10 @@
 
 import {ToolboxClient} from '../../src/toolbox_core/client.js';
 import {ToolboxTool} from '../../src/toolbox_core/tool.js';
-import {getSupportedMcpVersions} from '../../src/toolbox_core/protocol.js';
+import {
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../src/toolbox_core/protocol.js';
 
 import {AxiosError} from 'axios';
 import {CustomGlobal} from './types.js';
@@ -618,3 +621,18 @@ describe.each(getSupportedMcpVersions())(
     });
   },
 );
+
+describe('ToolboxClient E2E Protocol Negotiation Fallback', () => {
+  it('should successfully fallback to a supported version when draft specs are disabled on the server', async () => {
+    const testBaseUrl = 'http://localhost:5000';
+    const client = new ToolboxClient(
+      testBaseUrl,
+      undefined,
+      undefined,
+      Protocol.MCP_DRAFT_2026_v1,
+    );
+
+    const tool = await client.loadTool('get-n-rows');
+    expect(tool.getName()).toBe('get-n-rows');
+  });
+});

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -1,0 +1,549 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {McpHttpTransportV20260618} from '../../src/toolbox_core/mcp/v20260618/mcp.js';
+import {jest} from '@jest/globals';
+import axios, {AxiosInstance, AxiosError} from 'axios';
+
+import {Protocol} from '../../src/toolbox_core/protocol.js';
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios') as {
+    default: typeof import('axios');
+  };
+  return {
+    __esModule: true,
+    ...actual,
+    default: {
+      ...actual.default,
+      create: jest.fn(),
+    },
+  };
+});
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('McpHttpTransportV20260618', () => {
+  const testBaseUrl = 'http://test.loc';
+  let mockSession: jest.Mocked<AxiosInstance>;
+  let transport: McpHttpTransportV20260618;
+  let consoleWarnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    mockSession = {
+      get: jest.fn(),
+      post: jest.fn(),
+      defaults: {headers: {}},
+      interceptors: {
+        request: {use: jest.fn()},
+        response: {use: jest.fn()},
+      },
+    } as unknown as jest.Mocked<AxiosInstance>;
+
+    mockedAxios.create.mockReturnValue(mockSession);
+    transport = new McpHttpTransportV20260618(
+      testBaseUrl,
+      mockSession,
+      Protocol.MCP_DRAFT_2026_v1,
+    );
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('initialization', () => {
+    it('should not perform initialize handshake (no-op)', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      await transport.toolsList();
+
+      // Only tools/list request should be made, no initialize or initialized notification
+      expect(mockSession.post).toHaveBeenCalledTimes(1);
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        `${testBaseUrl}/mcp/`,
+        expect.objectContaining({
+          method: 'tools/list',
+          params: {
+            _meta: expect.objectContaining({
+              protocolVersion: 'DRAFT-2026-v1',
+            }),
+          },
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('toolsList', () => {
+    it('should return converted tools', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [
+              {
+                name: 'testTool',
+                description: 'A test tool',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    x: {type: 'string'},
+                  },
+                },
+              },
+            ],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const manifest = await transport.toolsList();
+
+      expect(manifest.tools['testTool']).toBeDefined();
+      expect(manifest.tools['testTool'].description).toBe('A test tool');
+      expect(manifest.tools['testTool'].parameters).toBeDefined();
+    });
+
+    it('should throw if toolsList returns no response (204)', async () => {
+      mockSession.post.mockResolvedValueOnce({
+        status: 204,
+        data: null,
+      });
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolsList()).rejects.toThrow(
+        'Failed to list tools: No response from server.',
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('toolGet', () => {
+    it('should return specific tool manifest', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [
+              {
+                name: 'targetTool',
+                description: 'desc',
+                inputSchema: {type: 'object'},
+              },
+              {
+                name: 'otherTool',
+                description: 'desc2',
+                inputSchema: {type: 'object'},
+              },
+            ],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const manifest = await transport.toolGet('targetTool');
+
+      expect(manifest.tools).toHaveProperty('targetTool');
+      expect(Object.keys(manifest.tools).length).toBe(1);
+    });
+
+    it('should throw if tool not found', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {tools: []},
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolGet('missing')).rejects.toThrow(
+        /Tool 'missing' not found/,
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('toolInvoke', () => {
+    it('should invoke tool and return text content', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '2',
+          result: {
+            content: [{type: 'text', text: 'Result output'}],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      const result = await transport.toolInvoke('testTool', {arg: 'val'}, {});
+
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        `${testBaseUrl}/mcp/`,
+        expect.objectContaining({
+          method: 'tools/call',
+          params: {
+            name: 'testTool',
+            arguments: {arg: 'val'},
+            _meta: expect.objectContaining({
+              protocolVersion: 'DRAFT-2026-v1',
+            }),
+          },
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+          }),
+        }),
+      );
+      expect(result).toBe('Result output');
+    });
+
+    it('should handle JSON-RPC errors', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const errorResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '2',
+          error: {
+            code: -32601,
+            message: 'Method not found',
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(errorResponse);
+
+      await expect(transport.toolInvoke('badTool', {}, {})).rejects.toThrow(
+        /MCP request failed with code -32601: Method not found/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should handle HTTP errors', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const httpErrorResponse = {
+        data: 'Server Error',
+        status: 500,
+        statusText: 'Internal Server Error',
+      };
+
+      mockSession.post.mockResolvedValueOnce(httpErrorResponse);
+
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        /API request failed with status 500/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw if toolInvoke returns no response (204)', async () => {
+      mockSession.post.mockResolvedValueOnce({
+        status: 204,
+        data: null,
+      });
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        "Failed to invoke tool 'testTool': No response from server.",
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw if toolInvoke returns invalid JSON-RPC structure', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const invalidResponse = {
+        data: {
+          foo: 'bar',
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invalidResponse);
+
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        'Failed to parse JSON-RPC response structure',
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('version negotiation', () => {
+    it('should throw ProtocolNegotiationError if server returns code -32022 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32022,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-11-25'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns invalid protocol version string', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw Error if server returns code -32022 with no mutually supported version', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32022,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['invalid-older-version'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw Error if server returns invalid protocol version but no fallback remains', async () => {
+      const oldestTransport = new McpHttpTransportV20260618(
+        testBaseUrl,
+        mockSession,
+        Protocol.MCP_v20241105,
+      );
+
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(oldestTransport.toolsList()).rejects.toThrow(
+        /no fallback versions remain/,
+      );
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('security and headers', () => {
+    it('should warn if sending headers over HTTP', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {content: []},
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      await transport.toolInvoke(
+        'testTool',
+        {arg: 'val'},
+        {Authorization: 'Bearer token'},
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'This connection is using HTTP. To prevent credential exposure, please ensure all communication is sent over HTTPS.',
+        ),
+      );
+    });
+
+    it('should not warn if using HTTPS', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {content: []},
+        },
+        status: 200,
+      };
+      // Create HTTPS transport
+      const httpsTransport = new McpHttpTransportV20260618(
+        'https://secure.test.loc',
+        mockSession,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      await httpsTransport.toolInvoke(
+        'testTool',
+        {arg: 'val'},
+        {Authorization: 'Bearer token'},
+      );
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -25,6 +25,8 @@ import {McpHttpTransportV20241105} from '../src/toolbox_core/mcp/v20241105/mcp.j
 import {McpHttpTransportV20250326} from '../src/toolbox_core/mcp/v20250326/mcp.js';
 import {McpHttpTransportV20250618} from '../src/toolbox_core/mcp/v20250618/mcp.js';
 import {McpHttpTransportV20251125} from '../src/toolbox_core/mcp/v20251125/mcp.js';
+import {McpHttpTransportV20260618} from '../src/toolbox_core/mcp/v20260618/mcp.js';
+import {ProtocolNegotiationError} from '../src/toolbox_core/errorUtils.js';
 
 // --- Mock Transport Implementation ---
 class MockTransport implements ITransport {
@@ -73,6 +75,14 @@ jest.mock('../src/toolbox_core/mcp/v20251125/mcp', () => {
   };
 });
 
+// Mock the McpHttpTransportV20260618 module
+jest.mock('../src/toolbox_core/mcp/v20260618/mcp', () => {
+  return {
+    __esModule: true,
+    McpHttpTransportV20260618: jest.fn(),
+  };
+});
+
 describe('ToolboxClient', () => {
   const testBaseUrl = 'https://api.example.com';
   let mockTransport: MockTransport;
@@ -93,6 +103,9 @@ describe('ToolboxClient', () => {
       () => mockTransport,
     );
     (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+      () => mockTransport,
+    );
+    (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
       () => mockTransport,
     );
   });
@@ -603,6 +616,95 @@ describe('ToolboxClient', () => {
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('This connection is using HTTP'),
       );
+    });
+  });
+
+  describe('Protocol Fallback', () => {
+    it('should fall back to supported version in loadTool when transport throws ProtocolNegotiationError', async () => {
+      const draftTransport = new MockTransport(testBaseUrl);
+      const fallbackTransport = new MockTransport(testBaseUrl);
+
+      draftTransport.toolGet.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      fallbackTransport.toolGet.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {
+          testTool: {
+            description: 'desc',
+            parameters: [],
+          },
+        },
+      });
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return draftTransport;
+        },
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return fallbackTransport;
+        },
+      );
+
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      const tool = await client.loadTool('testTool');
+      expect(tool.getName()).toBe('testTool');
+      expect(draftTransport.toolGet).toHaveBeenCalledTimes(1);
+      expect(fallbackTransport.toolGet).toHaveBeenCalledTimes(1);
+      expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to supported version in loadToolset when transport throws ProtocolNegotiationError', async () => {
+      const draftTransport = new MockTransport(testBaseUrl);
+      const fallbackTransport = new MockTransport(testBaseUrl);
+
+      draftTransport.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      fallbackTransport.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {
+          testTool: {
+            description: 'desc',
+            parameters: [],
+          },
+        },
+      });
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return draftTransport;
+        },
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return fallbackTransport;
+        },
+      );
+
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      const tools = await client.loadToolset('set');
+      expect(tools.length).toBe(1);
+      expect(tools[0].getName()).toBe('testTool');
+      expect(draftTransport.toolsList).toHaveBeenCalledTimes(1);
+      expect(fallbackTransport.toolsList).toHaveBeenCalledTimes(1);
+      expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Description

Implements [SEP-2575](https://modelcontextprotocol.io/seps/2575-stateless-mcp), introducing support for the Stateless MCP Draft protocol version. This removes the legacy stateful `initialize` JSON-RPC handshake and replaces it with a stateless HTTP header (`Mcp-Protocol-Version`).

## Changes
- Added new transport files (`mcp.ts` and `types.ts`) that remove the `initialize` method in favor of stateless headers.
- Updated `ToolboxClient` to catch `ProtocolNegotiationError` and fallback to older protocol versions if the server requires it.
- Added unit tests to verify the stateless communication structure.

> [!NOTE]
> This PR is the JS counterpart to https://github.com/googleapis/mcp-toolbox-sdk-python/pull/648.
