### PR TITLE
feat(core): implement SEP-2243 routing headers for HTTP transport

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -44,12 +44,13 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
   #checkProtocolNegotiationError(errVal: unknown): void {
     if (!errVal) return;
 
-    // Check for unsupported protocol version error code (-32022)
+    // Check for unsupported protocol version error code (-32022 or -32004)
     if (
       typeof errVal === 'object' &&
       errVal !== null &&
       'code' in errVal &&
-      (errVal as Record<string, unknown>).code === -32022
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
     ) {
       const serverSupported = ((
         (errVal as Record<string, unknown>).data as Record<string, unknown>
@@ -71,19 +72,16 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
     }
 
     // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
     const isLegacyError =
-      (typeof errVal === 'string' &&
-        (errVal.toLowerCase().includes('invalid protocol version') ||
-          errVal.toLowerCase().includes('unsupported protocol version'))) ||
-      (typeof errVal === 'object' &&
-        errVal !== null &&
-        'message' in errVal &&
-        (String((errVal as Record<string, unknown>).message)
-          .toLowerCase()
-          .includes('invalid protocol version') ||
-          String((errVal as Record<string, unknown>).message)
-            .toLowerCase()
-            .includes('unsupported protocol version')));
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
 
     if (isLegacyError) {
       // Cascading Fallback
@@ -131,6 +129,23 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
     // Inject Protocol Version into headers as required by MCP spec
     const reqHeaders = {...(headers || {})};
     reqHeaders['MCP-Protocol-Version'] = this._protocolVersion;
+
+    // Inject SEP-2243 routing headers
+    reqHeaders['Mcp-Method'] = method;
+    if (typeof params === 'object' && params !== null) {
+      if (
+        (method === 'tools/call' || method === 'prompts/get') &&
+        'name' in params
+      ) {
+        reqHeaders['Mcp-Name'] = String(
+          (params as Record<string, unknown>).name,
+        );
+      } else if (method === 'resources/read' && 'uri' in params) {
+        reqHeaders['Mcp-Name'] = String(
+          (params as Record<string, unknown>).uri,
+        );
+      }
+    }
 
     try {
       const response = await this._session.post(url, payload, {
@@ -189,6 +204,9 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
 
       return null;
     } catch (error) {
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
       if (error instanceof AxiosError) {
         const jsonResp = error.response?.data;
         if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
@@ -275,7 +293,9 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       warnIfHttpAndHeaders(this._mcpBaseUrl, headers);
     }
 
-    const params = {
+    const params: types.CallToolRequestParams & {
+      _meta?: Record<string, unknown>;
+    } = {
       name: toolName,
       arguments: arguments_,
       _meta: this.#getMeta(),

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -23,7 +23,7 @@ export enum Protocol {
   MCP = MCP_v20250618, // Default MCP
 }
 
-export const MCP_LATEST = Protocol.MCP_DRAFT_2026_v1;
+export const MCP_LATEST = Protocol.MCP_v20251125;
 
 export function getSupportedMcpVersions(): Protocol[] {
   return [

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -131,6 +131,20 @@ describe('McpHttpTransportV20260618', () => {
 
       const manifest = await transport.toolsList();
 
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+            'Mcp-Method': 'tools/list',
+          }),
+        }),
+      );
+      expect(
+        mockSession.post.mock.calls[0][2]?.headers?.['Mcp-Name'],
+      ).toBeUndefined();
+
       expect(manifest.tools['testTool']).toBeDefined();
       expect(manifest.tools['testTool'].description).toBe('A test tool');
       expect(manifest.tools['testTool'].parameters).toBeDefined();
@@ -238,6 +252,8 @@ describe('McpHttpTransportV20260618', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'MCP-Protocol-Version': 'DRAFT-2026-v1',
+            'Mcp-Method': 'tools/call',
+            'Mcp-Name': 'testTool',
           }),
         }),
       );
@@ -360,7 +376,51 @@ describe('McpHttpTransportV20260618', () => {
         .mockImplementation(() => {});
 
       await expect(transport.toolsList()).rejects.toThrow(
-        ProtocolNegotiationError,
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32004,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-11-25'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
 
       errorSpy.mockRestore();
@@ -398,7 +458,7 @@ describe('McpHttpTransportV20260618', () => {
         .mockImplementation(() => {});
 
       await expect(transport.toolsList()).rejects.toThrow(
-        ProtocolNegotiationError,
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
 
       errorSpy.mockRestore();


### PR DESCRIPTION
## Description

Implements [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization) to standardize HTTP transport bindings across the client.

This ensures conformance with the latest draft specification requirements for standardized headers and HTTP routing.

## Changes

### 1. SEP-2243 Routing Headers
* Injected the following HTTP headers for outgoing requests: for `tools/list`, `tools/call`, `prompts/get`, `resources/read`.
  * `Mcp-Name`: Injected conditionally:
    * Set to the tool name for `tools/call`.
    * Set to the prompt name for `prompts/get`.
    * Set to the resource URI for `resources/read`.
* Updated HTTP transport unit tests to assert that `Mcp-Method` and `Mcp-Name` are correctly injected and populated under matching conditions.

### 2. Protocol Negotiation & Error Handling
* Added `-32004` (Unsupported protocol version) to `#checkProtocolNegotiationError` alongside `-32022`, enabling protocol fallback.
* Streamlined checking for substring errors (`invalid protocol version` / `unsupported protocol version`) on both string and object error responses.
* Explicitly rethrow `ProtocolNegotiationError` in the transport request catch block to ensure negotiation failures bubble up instead of being swallowed.
* Added a test case validating that the transport throws a `ProtocolNegotiationError` when the server responds with error code `-32004` and a list of supported versions.

### 3. Protocol and Typings
* Adjusted `MCP_LATEST` to resolve to `Protocol.MCP_v20251125` (pinning it to the stable version).
* Clarified the type signature of parameters in `toolCall` to explicitly support the optional `_meta` field.

> [!NOTE]
> This PR is somewhat analogous to Python SDK's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/701.