### PR TITLE
ci: allow fork checkout for lint workflows

### DIFF
--- a/.github/workflows/lint-toolbox-adk.yaml
+++ b/.github/workflows/lint-toolbox-adk.yaml
@@ -64,6 +64,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
+          # Checking out fork code is gated behind the 'tests: run' label,
+          # which requires maintainer review before this workflow runs.
+          allow-unsafe-pr-checkout: true
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/lint-toolbox-core.yaml
+++ b/.github/workflows/lint-toolbox-core.yaml
@@ -64,6 +64,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
+          # Checking out fork code is gated behind the 'tests: run' label,
+          # which requires maintainer review before this workflow runs.
+          allow-unsafe-pr-checkout: true
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Description

`actions/checkout@v7` refuses to check out fork PR code in a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set. The lint workflows intentionally check out fork head code, gated behind the `tests: run` label, so this opts back in.

Must land on `main` to take effect, since `pull_request_target` runs the base branch's workflow. Fixes the failing lint check on fork PRs (e.g. #392).
