### PR TITLE
fix(ci): harden workflows and resolve zizmor security findings

### DIFF
--- a/.github/workflows/api-docs-backfill.yml
+++ b/.github/workflows/api-docs-backfill.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: refs/tags/${{ inputs.package }}-${{ inputs.version }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -40,7 +40,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        # No `cache:` input is set, so setup-node performs no dependency
+        # caching here; there is no runtime cache for a fork PR to poison.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 22.16.0
 

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -92,9 +93,12 @@ jobs:
         if: steps.resolve.outputs.packages != ''
         run: |
           chmod +x scripts/generate-api-docs.sh
-          for PKG in ${{ steps.resolve.outputs.packages }}; do
-            ./scripts/generate-api-docs.sh "$PKG" "${{ steps.resolve.outputs.version }}" "$BASE_URL"
+          for PKG in ${STEPS_RESOLVE_OUTPUTS_PACKAGES}; do
+            ./scripts/generate-api-docs.sh "$PKG" "${STEPS_RESOLVE_OUTPUTS_VERSION}" "$BASE_URL"
           done
+        env:
+          STEPS_RESOLVE_OUTPUTS_PACKAGES: ${{ steps.resolve.outputs.packages }}
+          STEPS_RESOLVE_OUTPUTS_VERSION: ${{ steps.resolve.outputs.version }}
 
       - name: Build root page
         if: steps.resolve.outputs.packages != '' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/cloud_build_failure_reporter.yml
+++ b/.github/workflows/cloud_build_failure_reporter.yml
@@ -38,10 +38,12 @@ jobs:
 
     steps:
       - uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9
+        env:
+          TRIGGER_NAMES: ${{ inputs.trigger_names }}
         with:
           script: |-
                   // parse test names
-                  const testNameSubstring = '${{ inputs.trigger_names }}';
+                  const testNameSubstring = process.env.TRIGGER_NAMES;
                   const testNameFound = new Map(); //keeps track of whether each test is found
                   testNameSubstring.split(',').forEach(testName => {
                     testNameFound.set(testName, false); 
@@ -171,8 +173,8 @@ jobs:
                   const noTestFound = Array.from(testNameFound.values()).every(value => value === false);
                   if (noTestFound){
                     createOrCommentIssue(
-                      'Missing periodic tests: ${{ inputs.trigger_names }}',
-                      `No periodic test is found for triggers: ${{ inputs.trigger_names }}. Last checked from ${
+                      `Missing periodic tests: ${process.env.TRIGGER_NAMES}`,
+                      `No periodic test is found for triggers: ${process.env.TRIGGER_NAMES}. Last checked from ${
                         commits[0].html_url
                       } to ${commits[commits.length - 1].html_url}.`
                     );

--- a/.github/workflows/lint-toolbox-adk.yaml
+++ b/.github/workflows/lint-toolbox-adk.yaml
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 name: adk
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request:
     paths:
       - 'packages/toolbox-adk/**'
       - '!packages/toolbox-adk/**/*.md'
+  # pull_request_target only fires on `labeled`; running fork code is gated
+  # behind the maintainer-applied 'tests: run' label (see job `if:` guards),
+  # and no secrets or write token are exposed to untrusted fork code.
   pull_request_target:
     types: [labeled]
 

--- a/.github/workflows/lint-toolbox-core.yaml
+++ b/.github/workflows/lint-toolbox-core.yaml
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 name: core
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request:
     paths:
       - 'packages/toolbox-core/**'
       - '!packages/toolbox-core/**/*.md'
+  # pull_request_target only fires on `labeled`; running fork code is gated
+  # behind the maintainer-applied 'tests: run' label (see job `if:` guards),
+  # and no secrets or write token are exposed to untrusted fork code.
   pull_request_target:
     types: [labeled]
 

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -30,6 +30,8 @@ jobs:
       pull-requests: 'write'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
Fixed findings by https://github.com/woodruffw/zizmor

## Fixes

**1. Template-injection fixes.** Inline `${{ }}` in scripts lets attacker input run as code. Fix: pass via `env:`, read as a variable.
- `cloud_build_failure_reporter.yml` (High): `inputs.trigger_names` to `process.env.TRIGGER_NAMES`.
- `api-docs.yml`: `steps.resolve.outputs.*` to shell env vars.

**2. Credential hardening.** `persist-credentials: false` stops checkout leaving the auth token in `.git/config`. Added to `api-docs.yml`, `api-docs-backfill.yml`, `sync-labels.yaml`, `update-lockfile.yaml`.

**3. Justified suppressions.** False positives silenced with explanatory comments:
- `api-docs.yml`: `cache-poisoning` (no cache configured).
- `lint-toolbox-adk/core.yaml`: `dangerous-triggers` (`pull_request_target` is label-gated, no secrets exposed).