### PR TITLE
feat: add support for protocol negotiation fallback with custom arrays

### DIFF
--- a/packages/toolbox-adk/src/toolbox_adk/client.ts
+++ b/packages/toolbox-adk/src/toolbox_adk/client.ts
@@ -46,7 +46,7 @@ export class ToolboxClient {
     url: string,
     session?: AxiosInstance | null,
     clientHeaders?: ClientHeadersConfig | null,
-    protocol: Protocol = Protocol.MCP,
+    protocol: Protocol | Protocol[] | string[] | string = Protocol.MCP,
   ) {
     this.coreClient = new CoreToolboxClient(
       url,

--- a/packages/toolbox-adk/test/e2e/test.e2e.ts
+++ b/packages/toolbox-adk/test/e2e/test.e2e.ts
@@ -151,6 +151,18 @@ testBaseUrls.forEach(testBaseUrl => {
         expect(loadedToolNames).toEqual(expectedDefaultTools);
       });
 
+      it('should successfully load the toolset with an explicit protocol', async () => {
+        const explicitClient = new ToolboxClient(
+          testBaseUrl,
+          undefined,
+          undefined,
+          Protocol.MCP_v20251125,
+        );
+        const loadedTools = await explicitClient.loadToolset();
+        expect(Array.isArray(loadedTools)).toBe(true);
+        expect(loadedTools.length).toBeGreaterThan(0);
+      });
+
       it('should throw an error when trying to load a non-existent toolset', async () => {
         await expect(
           commonToolboxClient.loadToolset('non-existent-toolset'),

--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -52,6 +52,7 @@ class ToolboxClient {
   #clientHeaders: ClientHeadersConfig;
   #session: AxiosInstance | undefined;
   #baseUrl: string;
+  #supportedProtocols: string[];
 
   /**
    * The negotiated protocol version currently in use.
@@ -73,7 +74,7 @@ class ToolboxClient {
     url: string,
     session?: AxiosInstance | null,
     clientHeaders?: ClientHeadersConfig | null,
-    protocol: Protocol = Protocol.MCP,
+    protocol: Protocol | Protocol[] | string[] | string = Protocol.MCP,
     clientName?: string,
     clientVersion?: string,
   ) {
@@ -81,14 +82,47 @@ class ToolboxClient {
     this.#clientHeaders = clientHeaders || {};
     this.#session = session || undefined;
     warnIfHttpAndHeaders(url, this.#clientHeaders);
-    if (!getSupportedMcpVersions().includes(protocol)) {
-      throw new Error(`Unsupported protocol version: ${protocol}`);
+
+    let initialProtocol: Protocol;
+    if (Array.isArray(protocol)) {
+      if (protocol.length === 0) {
+        throw new Error('Protocol array cannot be empty');
+      }
+
+      const globalSupported = getSupportedMcpVersions();
+
+      for (const p of protocol) {
+        if (!globalSupported.includes(p as Protocol)) {
+          throw new Error(
+            `Invalid protocol version '${p}'. Must be one of: ${globalSupported.join(', ')}`,
+          );
+        }
+      }
+
+      const requestedSet = new Set<string>(protocol);
+      const sorted = globalSupported.filter(globalVer =>
+        requestedSet.has(globalVer),
+      );
+
+      if (sorted.length === 0) {
+        throw new Error('None of the provided protocols are supported');
+      }
+
+      this.#supportedProtocols = sorted;
+      initialProtocol = sorted[0] as Protocol; // Start with the highest requested version
+    } else {
+      initialProtocol = protocol as Protocol;
+      const globalSupported = getSupportedMcpVersions();
+      if (!globalSupported.includes(initialProtocol)) {
+        throw new Error(`Invalid protocol version '${initialProtocol}'`);
+      }
+      this.#supportedProtocols = globalSupported;
     }
 
-    this.#transport = this.#createTransport(
+    this.#transport = this.#createTransportWithProtocols(
       url,
       session || undefined,
-      protocol,
+      initialProtocol,
       clientName,
       clientVersion,
     );
@@ -145,6 +179,26 @@ class ToolboxClient {
       default:
         throw new Error(`Unsupported MCP protocol version: ${protocol}`);
     }
+  }
+
+  #createTransportWithProtocols(
+    url: string,
+    session: AxiosInstance | undefined,
+    protocol: Protocol,
+    clientName?: string,
+    clientVersion?: string,
+  ): ITransport {
+    const transport = this.#createTransport(
+      url,
+      session,
+      protocol,
+      clientName,
+      clientVersion,
+    );
+    if (this.#supportedProtocols) {
+      transport.supportedProtocols = this.#supportedProtocols;
+    }
+    return transport;
   }
 
   /**
@@ -218,6 +272,49 @@ class ToolboxClient {
     return {tool, usedAuthKeys, usedBoundKeys};
   }
 
+  async #executeWithFallback<T>(action: () => Promise<T>): Promise<T> {
+    while (true) {
+      try {
+        return await action();
+      } catch (e: unknown) {
+        if (e instanceof ProtocolNegotiationError) {
+          const serverVersion = e.fallbackVersion as string;
+          let mutuallySupported: string[] | null = null;
+
+          if (this.#supportedProtocols.includes(serverVersion as Protocol)) {
+            mutuallySupported = [serverVersion];
+          } else {
+            const allVersions = getSupportedMcpVersions();
+            if (allVersions.includes(serverVersion as Protocol)) {
+              const idx = allVersions.indexOf(serverVersion as Protocol);
+              const serverSupported = allVersions.slice(idx);
+              mutuallySupported = this.#supportedProtocols.filter(v =>
+                serverSupported.includes(v as Protocol),
+              );
+            }
+          }
+
+          if (!mutuallySupported || mutuallySupported.length === 0) {
+            throw new Error('No mutually supported protocol version');
+          }
+
+          const fallbackProtocol = mutuallySupported[0] as Protocol;
+          if (fallbackProtocol === this.#transport.protocolVersion) {
+            throw e;
+          }
+
+          this.#transport = this.#createTransportWithProtocols(
+            this.#baseUrl,
+            this.#session,
+            fallbackProtocol,
+          );
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
   /**
    * Asynchronously loads a tool from the server.
    * Retrieves the schema for the specified tool from the Toolbox server and
@@ -239,21 +336,9 @@ class ToolboxClient {
   ): Promise<ToolboxTool> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const headers = await this.#resolveClientHeaders();
-    let manifest;
-    try {
-      manifest = await this.#transport.toolGet(name, headers);
-    } catch (e: unknown) {
-      if (e instanceof ProtocolNegotiationError) {
-        this.#transport = this.#createTransport(
-          this.#baseUrl,
-          this.#session,
-          e.fallbackVersion,
-        );
-        manifest = await this.#transport.toolGet(name, headers);
-      } else {
-        throw e;
-      }
-    }
+    const manifest = await this.#executeWithFallback(() =>
+      this.#transport.toolGet(name, headers),
+    );
 
     if (
       manifest.tools &&
@@ -324,21 +409,9 @@ class ToolboxClient {
     const toolsetName = name || '';
     const headers = await this.#resolveClientHeaders();
 
-    let manifest;
-    try {
-      manifest = await this.#transport.toolsList(toolsetName, headers);
-    } catch (e: unknown) {
-      if (e instanceof ProtocolNegotiationError) {
-        this.#transport = this.#createTransport(
-          this.#baseUrl,
-          this.#session,
-          e.fallbackVersion,
-        );
-        manifest = await this.#transport.toolsList(toolsetName, headers);
-      } else {
-        throw e;
-      }
-    }
+    const manifest = await this.#executeWithFallback(() =>
+      this.#transport.toolsList(toolsetName, headers),
+    );
     const tools: ToolboxTool[] = [];
 
     const overallUsedAuthKeys: Set<string> = new Set();

--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -45,6 +45,7 @@ export abstract class McpHttpTransportBase implements ITransport {
   protected _mcpBaseUrl: string;
   protected _protocolVersion: string;
   protected _serverVersion: string | null = null;
+  public supportedProtocols?: string[];
 
   protected _manageSession: boolean;
   protected _session: AxiosInstance;

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -28,6 +28,68 @@ import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20250618 extends McpHttpTransportBase {
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022 or -32004)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
+    const isLegacyError =
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -81,7 +143,10 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -113,61 +178,20 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
 
       return null;
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'isAxiosError' in error &&
-        (error as AxiosError).response?.status === 400 &&
-        (error as AxiosError).response?.data &&
-        typeof (error as AxiosError).response?.data === 'object' &&
-        'error' in
-          ((error as AxiosError).response?.data as Record<string, unknown>)
-      ) {
-        const errorData = (error as AxiosError).response?.data as Record<
-          string,
-          unknown
-        >;
-        const errObj = errorData.error;
-
-        if (
-          typeof errObj === 'string' &&
-          errObj.includes('invalid protocol version')
-        ) {
-          throw new ProtocolNegotiationError(Protocol.MCP_v20250326);
-        }
-
-        if (
-          typeof errObj === 'object' &&
-          errObj !== null &&
-          'code' in errObj &&
-          (errObj as Record<string, unknown>).code === -32004
-        ) {
-          const errData = (errObj as Record<string, unknown>).data;
-          if (
-            errData &&
-            typeof errData === 'object' &&
-            'supported' in errData
-          ) {
-            const supported = (errData as Record<string, unknown>).supported;
-            if (Array.isArray(supported) && supported.length > 0) {
-              let mutuallySupportedVersion: string | null = null;
-              for (const ourVer of getSupportedMcpVersions()) {
-                if (supported.includes(ourVer)) {
-                  mutuallySupportedVersion = ourVer;
-                  break;
-                }
-              }
-              if (mutuallySupportedVersion) {
-                throw new ProtocolNegotiationError(
-                  mutuallySupportedVersion as Protocol,
-                );
-              }
-              throw new ProtocolNegotiationError(supported[0] as Protocol);
-            }
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
+      if (error && typeof error === 'object' && 'isAxiosError' in error) {
+        const jsonResp = (error as AxiosError).response?.data;
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
           }
         }
       }
-
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
@@ -28,6 +28,68 @@ import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20251125 extends McpHttpTransportBase {
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022 or -32004)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
+    const isLegacyError =
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -81,7 +143,10 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -113,57 +178,17 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       return null;
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'isAxiosError' in error &&
-        (error as AxiosError).response?.status === 400 &&
-        (error as AxiosError).response?.data &&
-        typeof (error as AxiosError).response?.data === 'object' &&
-        'error' in
-          ((error as AxiosError).response?.data as Record<string, unknown>)
-      ) {
-        const errorData = (error as AxiosError).response?.data as Record<
-          string,
-          unknown
-        >;
-        const errObj = errorData.error;
-
-        if (
-          typeof errObj === 'string' &&
-          errObj.includes('invalid protocol version')
-        ) {
-          throw new ProtocolNegotiationError(Protocol.MCP_v20250618);
-        }
-
-        if (
-          typeof errObj === 'object' &&
-          errObj !== null &&
-          'code' in errObj &&
-          (errObj as Record<string, unknown>).code === -32004
-        ) {
-          const errData = (errObj as Record<string, unknown>).data;
-          if (
-            errData &&
-            typeof errData === 'object' &&
-            'supported' in errData
-          ) {
-            const supported = (errData as Record<string, unknown>).supported;
-            if (Array.isArray(supported) && supported.length > 0) {
-              let mutuallySupportedVersion: string | null = null;
-              for (const ourVer of getSupportedMcpVersions()) {
-                if (supported.includes(ourVer)) {
-                  mutuallySupportedVersion = ourVer;
-                  break;
-                }
-              }
-              if (mutuallySupportedVersion) {
-                throw new ProtocolNegotiationError(
-                  mutuallySupportedVersion as Protocol,
-                );
-              }
-              throw new ProtocolNegotiationError(supported[0] as Protocol);
-            }
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
+      if (error && typeof error === 'object' && 'isAxiosError' in error) {
+        const jsonResp = (error as AxiosError).response?.data;
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
           }
         }
       }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -55,13 +55,14 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       const serverSupported = ((
         (errVal as Record<string, unknown>).data as Record<string, unknown>
       )?.supported || []) as string[];
-      const clientSupported = getSupportedMcpVersions();
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
       const mutuallySupported = clientSupported.filter(v =>
         serverSupported.includes(v),
       );
 
       if (mutuallySupported.length > 0) {
-        throw new ProtocolNegotiationError(mutuallySupported[0]);
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
       } else {
         throw new Error(
           `No mutually supported protocol version. Client supports: ${clientSupported.join(
@@ -85,12 +86,15 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
 
     if (isLegacyError) {
       // Cascading Fallback
-      const clientSupported = getSupportedMcpVersions();
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
       const currentIdx = clientSupported.indexOf(
         this._protocolVersion as Protocol,
       );
       if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
-        throw new ProtocolNegotiationError(clientSupported[currentIdx + 1]);
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
       } else {
         throw new Error(
           "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
@@ -209,9 +213,13 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       }
       if (error instanceof AxiosError) {
         const jsonResp = error.response?.data;
-        if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
-          const errVal = (jsonResp as Record<string, unknown>).error;
-          this.#checkProtocolNegotiationError(errVal);
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
+          }
         }
       }
       logApiError(`Error posting data to ${url}:`, error);

--- a/packages/toolbox-core/src/toolbox_core/transport.types.ts
+++ b/packages/toolbox-core/src/toolbox_core/transport.types.ts
@@ -27,6 +27,11 @@ export interface ITransport {
   readonly protocolVersion: string;
 
   /**
+   * The list of supported protocols that the client claims to support.
+   */
+  supportedProtocols?: string[];
+
+  /**
    * The base URL for the transport.
    */
   readonly baseUrl: string;

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -25,9 +25,9 @@ import {CustomGlobal} from './types.js';
 import {authTokenGetter} from './utils.js';
 import {ZodTypeAny} from 'zod';
 
-const LEGACY_SERVER_URL = 'http://localhost:5000';
-const DRAFT_SERVER_URL = 'http://localhost:5001';
-const testBaseUrls = [LEGACY_SERVER_URL, DRAFT_SERVER_URL];
+const TOOLBOX_SERVER_URL_STABLE = 'http://localhost:5000';
+const TOOLBOX_SERVER_URL_DRAFT = 'http://localhost:5001';
+const testBaseUrls = [TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT];
 
 testBaseUrls.forEach(testBaseUrl => {
   describe.each(getSupportedMcpVersions())(
@@ -651,7 +651,7 @@ testBaseUrls.forEach(testBaseUrl => {
       expect(response).toContain('row1');
     });
 
-    if (testBaseUrl === LEGACY_SERVER_URL) {
+    if (testBaseUrl === TOOLBOX_SERVER_URL_STABLE) {
       it('should fallback to an older protocol against a server that does not support the draft version', async () => {
         const session = axios.create();
         const postSpy = jest.spyOn(session, 'post');
@@ -672,7 +672,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 1: Draft tools/list (fails)
         const call1 = postSpy.mock.calls[0];
-        expect(call1[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
@@ -680,7 +680,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 2: Stateful Initialize (succeeds)
         const call2 = postSpy.mock.calls[1];
-        expect(call2[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call2[1] as Record<string, unknown>).method).toBe('initialize');
         expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
@@ -688,7 +688,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 3: Stateful Initialized Notification (succeeds)
         const call3 = postSpy.mock.calls[2];
-        expect(call3[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call3[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call3[1] as Record<string, unknown>).method).toBe(
           'notifications/initialized',
         );
@@ -698,7 +698,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 4: Stateful tools/list (succeeds)
         const call4 = postSpy.mock.calls[3];
-        expect(call4[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call4[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call4[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call4[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
@@ -706,13 +706,13 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 5: Stateful tools/call (succeeds)
         const call5 = postSpy.mock.calls[4];
-        expect(call5[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call5[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call5[1] as Record<string, unknown>).method).toBe('tools/call');
         expect(call5[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
         );
       });
-    } else if (testBaseUrl === DRAFT_SERVER_URL) {
+    } else if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
       it('should successfully connect using the draft version without fallback', async () => {
         const session = axios.create();
         const postSpy = jest.spyOn(session, 'post');
@@ -728,12 +728,13 @@ testBaseUrls.forEach(testBaseUrl => {
         const response = await tool({num_rows: '1'});
         expect(typeof response).toBe('string');
         expect(response).toContain('row1');
+        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT_2026_v1);
 
         expect(postSpy).toHaveBeenCalledTimes(2);
 
         // Call 1: Draft tools/list (succeeds)
         const call1 = postSpy.mock.calls[0];
-        expect(call1[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
         expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
@@ -741,12 +742,48 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 2: Draft tools/call (succeeds)
         const call2 = postSpy.mock.calls[1];
-        expect(call2[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
         expect((call2[1] as Record<string, unknown>).method).toBe('tools/call');
         expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
         );
       });
     }
+
+    it('should correctly negotiate Protocol.MCP_LATEST', async () => {
+      const client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_LATEST,
+      );
+
+      const tool = await client.loadTool('get-n-rows');
+      const response = await tool({num_rows: '1'});
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
+
+      expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+    });
+
+    it('should correctly negotiate with a custom list [Protocol.MCP_v20241105, Protocol.MCP_v20250326, Protocol.MCP_LATEST, Protocol.MCP_DRAFT]', async () => {
+      const client = new ToolboxClient(testBaseUrl, undefined, undefined, [
+        Protocol.MCP_v20241105,
+        Protocol.MCP_v20250326,
+        Protocol.MCP_LATEST,
+        Protocol.MCP_DRAFT,
+      ]);
+
+      const tool = await client.loadTool('get-n-rows');
+      const response = await tool({num_rows: '1'});
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
+
+      if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT);
+      } else {
+        expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+      }
+    });
   });
 });

--- a/packages/toolbox-core/test/mcp/test.v20250618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20250618.ts
@@ -231,6 +231,66 @@ describe('McpHttpTransportV20250618', () => {
       errorSpy.mockRestore();
     });
 
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2024-11-05'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw error if tools capability missing', async () => {
       const initResponse = {
         data: {
@@ -921,6 +981,62 @@ describe('McpHttpTransportV20250618', () => {
   });
 
   describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-03-26'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-03-26'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
       const rpcError = {
         jsonrpc: '2.0',

--- a/packages/toolbox-core/test/mcp/test.v20251125.ts
+++ b/packages/toolbox-core/test/mcp/test.v20251125.ts
@@ -231,6 +231,66 @@ describe('McpHttpTransportV20251125', () => {
       errorSpy.mockRestore();
     });
 
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2024-11-05'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw error if tools capability missing', async () => {
       const initResponse = {
         data: {
@@ -921,6 +981,62 @@ describe('McpHttpTransportV20251125', () => {
   });
 
   describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-06-18'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-06-18'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
       const rpcError = {
         jsonrpc: '2.0',

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -382,19 +382,7 @@ describe('McpHttpTransportV20260618', () => {
       errorSpy.mockRestore();
     });
 
-    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
-      const rpcError = {
-        jsonrpc: '2.0',
-        id: '1',
-        error: {
-          code: -32004,
-          message: 'Unsupported protocol version',
-          data: {
-            supported: ['2025-11-25'],
-          },
-        },
-      };
-
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
       const config =
         {} as unknown as import('axios').InternalAxiosRequestConfig;
       const response = {
@@ -402,7 +390,15 @@ describe('McpHttpTransportV20260618', () => {
         statusText: 'Bad Request',
         headers: {},
         config,
-        data: rpcError,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
       } as unknown as import('axios').AxiosResponse;
 
       const axiosError = new AxiosError(
@@ -422,7 +418,151 @@ describe('McpHttpTransportV20260618', () => {
       await expect(transport.toolsList()).rejects.toThrow(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
+      errorSpy.mockRestore();
+    });
 
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw error if server returns HTTP 200 with code -32004 and no intersection', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns HTTP 200 with invalid protocol version string', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: 'invalid protocol version',
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
       errorSpy.mockRestore();
     });
 
@@ -459,6 +599,70 @@ describe('McpHttpTransportV20260618', () => {
 
       await expect(transport.toolsList()).rejects.toThrow(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns a raw plain text string error (invalid protocol version)', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: 'invalid protocol version',
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns a raw plain text string error (invalid protocol version / fallback)', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: 'invalid protocol version',
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
       );
 
       errorSpy.mockRestore();

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -14,7 +14,11 @@
 
 import {jest} from '@jest/globals';
 import {ITransport} from '../src/toolbox_core/transport.types.js';
-import {ZodManifest, Protocol} from '../src/toolbox_core/protocol.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../src/toolbox_core/protocol.js';
 import type {ToolboxClient as ToolboxClientType} from '../src/toolbox_core/client.js';
 import {ToolboxClient} from '../src/toolbox_core/client.js';
 import {McpHttpTransportV20241105} from '../src/toolbox_core/mcp/v20241105/mcp.js';
@@ -28,6 +32,7 @@ import {ProtocolNegotiationError} from '../src/toolbox_core/errorUtils.js';
 class MockTransport implements ITransport {
   readonly baseUrl: string;
   protocolVersion = Protocol.MCP;
+  supportedProtocols?: Protocol[];
   toolGet: jest.MockedFunction<ITransport['toolGet']>;
   toolsList: jest.MockedFunction<ITransport['toolsList']>;
   toolInvoke: jest.MockedFunction<ITransport['toolInvoke']>;
@@ -77,6 +82,19 @@ jest.mock('../src/toolbox_core/mcp/v20260618/mcp', () => {
   return {
     __esModule: true,
     McpHttpTransportV20260618: jest.fn(),
+  };
+});
+
+// Mock the protocol module
+jest.mock('../src/toolbox_core/protocol', () => {
+  const original = jest.requireActual(
+    '../src/toolbox_core/protocol',
+  ) as unknown as Record<string, unknown>;
+  return {
+    ...original,
+    getSupportedMcpVersions: jest.fn(() =>
+      (original.getSupportedMcpVersions as () => Protocol[])(),
+    ),
   };
 });
 
@@ -257,7 +275,33 @@ describe('ToolboxClient', () => {
           undefined,
           'unknown-protocol' as Protocol,
         );
-      }).toThrow('Unsupported protocol version: unknown-protocol');
+      }).toThrow(/Invalid protocol version 'unknown-protocol'/);
+    });
+
+    it('should throw error for empty protocol array', () => {
+      expect(() => {
+        new ToolboxClient(testBaseUrl, undefined, undefined, []);
+      }).toThrow('Protocol array cannot be empty');
+    });
+
+    it('should throw error if any protocol in array is unsupported', () => {
+      expect(() => {
+        new ToolboxClient(testBaseUrl, undefined, undefined, [
+          '2025-11-25',
+          'unknown-protocol' as Protocol,
+        ]);
+      }).toThrow(/Invalid protocol version 'unknown-protocol'/);
+    });
+
+    it('should pass supportedProtocols to transport', () => {
+      client = new ToolboxClient(testBaseUrl, undefined, undefined, [
+        '2025-11-25',
+        'DRAFT-2026-v1',
+      ]);
+      expect(mockTransport.supportedProtocols).toEqual([
+        'DRAFT-2026-v1',
+        '2025-11-25',
+      ]);
     });
 
     it('should pass client name and version to transport', () => {
@@ -664,7 +708,9 @@ describe('ToolboxClient', () => {
   describe('Protocol Fallback', () => {
     it('should fall back to supported version in loadTool when transport throws ProtocolNegotiationError', async () => {
       const draftTransport = new MockTransport(testBaseUrl);
+      draftTransport.protocolVersion = Protocol.MCP_DRAFT;
       const fallbackTransport = new MockTransport(testBaseUrl);
+      fallbackTransport.protocolVersion = Protocol.MCP_v20251125;
 
       draftTransport.toolGet.mockRejectedValueOnce(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
@@ -695,7 +741,7 @@ describe('ToolboxClient', () => {
         testBaseUrl,
         undefined,
         undefined,
-        Protocol.MCP_DRAFT_2026_v1,
+        Protocol.MCP_DRAFT,
       );
 
       const tool = await client.loadTool('testTool');
@@ -707,7 +753,9 @@ describe('ToolboxClient', () => {
 
     it('should fall back to supported version in loadToolset when transport throws ProtocolNegotiationError', async () => {
       const draftTransport = new MockTransport(testBaseUrl);
+      draftTransport.protocolVersion = Protocol.MCP_DRAFT;
       const fallbackTransport = new MockTransport(testBaseUrl);
+      fallbackTransport.protocolVersion = Protocol.MCP_v20251125;
 
       draftTransport.toolsList.mockRejectedValueOnce(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
@@ -738,7 +786,7 @@ describe('ToolboxClient', () => {
         testBaseUrl,
         undefined,
         undefined,
-        Protocol.MCP_DRAFT_2026_v1,
+        Protocol.MCP_DRAFT,
       );
 
       const tools = await client.loadToolset('set');
@@ -747,6 +795,146 @@ describe('ToolboxClient', () => {
       expect(draftTransport.toolsList).toHaveBeenCalledTimes(1);
       expect(fallbackTransport.toolsList).toHaveBeenCalledTimes(1);
       expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Fallback Logic', () => {
+    let mockTransport1: MockTransport;
+    let mockTransport2: MockTransport;
+
+    beforeEach(() => {
+      mockTransport1 = new MockTransport(testBaseUrl);
+      mockTransport2 = new MockTransport(testBaseUrl);
+    });
+
+    it('should fallback when ProtocolNegotiationError is thrown (The Cascading Fallback Test)', async () => {
+      // Setup first transport to throw error with fallback version
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      // Setup second transport to succeed
+      mockTransport2.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {testTool: {description: 'test', parameters: []}},
+      });
+      mockTransport2.protocolVersion = Protocol.MCP_v20241105;
+
+      // The client uses the Latest/Draft by default initially.
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+      (McpHttpTransportV20241105 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport2,
+      );
+
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20241105,
+      ]);
+
+      const tools = await client.loadToolset('test');
+
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport2.toolsList).toHaveBeenCalledTimes(1);
+      expect(tools.length).toBe(1);
+      expect(client.protocolVersion).toBe(Protocol.MCP_v20241105);
+    });
+
+    it('should handle multi-step cascading fallbacks across three transport versions (Draft -> 20251125 -> 20241105)', async () => {
+      const mockTransport1 = new MockTransport(testBaseUrl);
+      mockTransport1.protocolVersion = Protocol.MCP_DRAFT;
+      const mockTransport2 = new MockTransport(testBaseUrl);
+      mockTransport2.protocolVersion = Protocol.MCP_v20251125;
+      const mockTransport3 = new MockTransport(testBaseUrl);
+
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      mockTransport2.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      mockTransport3.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {testTool: {description: 'test', parameters: []}},
+      });
+      mockTransport3.protocolVersion = Protocol.MCP_v20241105;
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport2,
+      );
+      (McpHttpTransportV20241105 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport3,
+      );
+
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20251125,
+        Protocol.MCP_v20241105,
+      ]);
+
+      const tools = await client.loadToolset('test');
+
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport2.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport3.toolsList).toHaveBeenCalledTimes(1);
+      expect(tools.length).toBe(1);
+      expect(client.protocolVersion).toBe(Protocol.MCP_v20241105);
+    });
+
+    it('should throw an error if server returns unsupported old version (The Strict Constraint Test)', async () => {
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+
+      // Client only supports Draft and 20251125, but server threw 20241105
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20251125,
+      ]);
+
+      await expect(client.loadToolset('test')).rejects.toThrow(
+        'No mutually supported protocol version',
+      );
+    });
+
+    it('should throw ProtocolNegotiationError if fallback version is equal to current transport version (infinite loop guard)', async () => {
+      mockTransport1.protocolVersion = Protocol.MCP_DRAFT;
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_DRAFT),
+      );
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+
+      const client = new ToolboxClient(
+        testBaseUrl,
+        null,
+        null,
+        Protocol.MCP_DRAFT,
+      );
+
+      await expect(client.loadToolset('test')).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error if transport creation hits default block with unsupported protocol version', () => {
+      (getSupportedMcpVersions as jest.Mock).mockReturnValueOnce([
+        '9999-01-01' as Protocol,
+      ]);
+
+      expect(() => {
+        new ToolboxClient(testBaseUrl, null, null, '9999-01-01' as Protocol);
+      }).toThrow('Unsupported MCP protocol version: 9999-01-01');
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds support for specifying a custom array of supported MCP protocol versions during `ToolboxClient` initialization. It also updates transport error parsing and client execution logic to handle cascading protocol negotiation and fallbacks seamlessly.

## Changes
- Updated `CoreToolboxClient` and ADK `ToolboxClient` initializers to accept `Protocol | Protocol[]`.
  - Validates non-empty arrays, verifies version support, and orders supported protocols by priority.
- Added `#executeWithFallback` to `CoreToolboxClient` to catch `ProtocolNegotiationError` and automatically attempt execution using the next mutually supported protocol version.
- Enhanced `v20250618`, `v20251125`, and `v20260618` transport implementations to parse raw server negotiation errors into structured `ProtocolNegotiationError` instances.
- **E2E Test Refactoring**: Updated E2E test suites with `TOOLBOX_SERVER_URL_STABLE` and `TOOLBOX_SERVER_URL_DRAFT` constants and added tests validating single-version and multi-version array fallback negotiation.
- **Unit & Integration Tests**: Added extensive test suites  and transport test files covering multi-step cascading fallbacks, strict version constraints, and validation errors.
- Added the Protocol Negotiation entry to `README.md`.

> [!NOTE]
> This PR is somewhat analogous to Python SDK's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/707.