### PR TITLE
feat(core): support 2026 Stateless MCP, array-based auto-negotiation, and HTTP transport routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ docs-site/resources/
 
 # Coverage
 coverage/
+
+# Build caches
+.turbo/
+
+# TypeScript build info
+*.tsbuildinfo

--- a/packages/toolbox-adk/src/toolbox_adk/client.ts
+++ b/packages/toolbox-adk/src/toolbox_adk/client.ts
@@ -46,7 +46,7 @@ export class ToolboxClient {
     url: string,
     session?: AxiosInstance | null,
     clientHeaders?: ClientHeadersConfig | null,
-    protocol: Protocol = Protocol.MCP,
+    protocol: Protocol | Protocol[] | string[] | string = Protocol.MCP,
   ) {
     this.coreClient = new CoreToolboxClient(
       url,

--- a/packages/toolbox-adk/test/e2e/jest.globalSetup.ts
+++ b/packages/toolbox-adk/test/e2e/jest.globalSetup.ts
@@ -57,102 +57,134 @@ export default async function globalSetup(): Promise<void> {
 
     const localToolboxPath = path.resolve(__dirname, TOOLBOX_BINARY_NAME);
 
+    const bucketName = 'mcp-toolbox-for-databases';
     console.log(
-      `Downloading toolbox binary from gs://mcp-toolbox-for-databases/${toolboxGcsPath} to ${localToolboxPath}...`,
+      `Downloading toolbox binary from gs://${bucketName}/${toolboxGcsPath} to ${localToolboxPath}...`,
     );
-    await downloadBlob(
-      'mcp-toolbox-for-databases',
-      toolboxGcsPath,
-      localToolboxPath,
-    );
+    await downloadBlob(bucketName, toolboxGcsPath, localToolboxPath);
     console.log('Toolbox binary downloaded successfully.');
 
     // Make toolbox executable
     await fs.chmod(localToolboxPath, 0o700);
 
-    // Start toolbox server
-    console.log('Starting toolbox server process...');
-    const serverProcess = spawn(
+    // Start toolbox servers
+    console.log('Starting toolbox server processes...');
+    const serverProcess1 = spawn(
       localToolboxPath,
-      ['--tools-file', toolsFilePath],
+      ['--port', '5000', '--tools-file', toolsFilePath],
       {
-        stdio: ['ignore', 'pipe', 'pipe'], // ignore stdin, pipe stdout/stderr
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    const serverProcess2 = spawn(
+      localToolboxPath,
+      ['--port', '5001', '--tools-file', toolsFilePath, '--enable-draft-specs'],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
       },
     );
 
-    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ = serverProcess;
+    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ = serverProcess1;
+    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS_2__ = serverProcess2;
 
-    serverProcess.stdout?.on('data', (data: Buffer) => {
-      console.log(`[ToolboxServer STDOUT]: ${data.toString().trim()}`);
+    serverProcess1.stdout?.on('data', (data: Buffer) => {
+      console.log(`[ToolboxServer1 STDOUT]: ${data.toString().trim()}`);
     });
-
-    serverProcess.stderr?.on('data', (data: Buffer) => {
-      console.error(`[ToolboxServer STDERR]: ${data.toString().trim()}`);
+    serverProcess1.stderr?.on('data', (data: Buffer) => {
+      console.error(`[ToolboxServer1 STDERR]: ${data.toString().trim()}`);
     });
-
-    serverProcess.on('error', err => {
-      console.error('Toolbox server process error:', err);
-      throw new Error('Failed to start toolbox server process.');
+    serverProcess1.on('error', err => {
+      console.error('Toolbox server 1 process error:', err);
+      throw new Error('Failed to start toolbox server 1 process.');
     });
-
-    serverProcess.on('exit', (code, signal) => {
+    serverProcess1.on('exit', (code, signal) => {
       console.log(
-        `Toolbox server process exited with code ${code}, signal ${signal}.`,
+        `Toolbox server 1 process exited with code ${code}, signal ${signal}.`,
       );
       if (
         (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ &&
         !(globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__
       ) {
-        console.error('Toolbox server exited prematurely during setup.');
+        console.error('Toolbox server 1 exited prematurely during setup.');
       }
     });
 
-    // Wait for server to start (basic poll check)
-    let started = false;
+    serverProcess2.stdout?.on('data', (data: Buffer) => {
+      console.log(`[ToolboxServer2 STDOUT]: ${data.toString().trim()}`);
+    });
+    serverProcess2.stderr?.on('data', (data: Buffer) => {
+      console.error(`[ToolboxServer2 STDERR]: ${data.toString().trim()}`);
+    });
+    serverProcess2.on('error', err => {
+      console.error('Toolbox server 2 process error:', err);
+      throw new Error('Failed to start toolbox server 2 process.');
+    });
+    serverProcess2.on('exit', (code, signal) => {
+      console.log(
+        `Toolbox server 2 process exited with code ${code}, signal ${signal}.`,
+      );
+      if (
+        (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS_2__ &&
+        !(globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__
+      ) {
+        console.error('Toolbox server 2 exited prematurely during setup.');
+      }
+    });
+
+    // Wait for servers to start (basic poll check)
+    let started1 = false;
+    let started2 = false;
     const startTime = Date.now();
     while (Date.now() - startTime < SERVER_READY_TIMEOUT_MS) {
       if (
-        serverProcess.pid &&
-        !serverProcess.killed &&
-        serverProcess.exitCode === null
+        serverProcess1.pid &&
+        !serverProcess1.killed &&
+        serverProcess1.exitCode === null
       ) {
+        started1 = true;
+      }
+      if (
+        serverProcess2.pid &&
+        !serverProcess2.killed &&
+        serverProcess2.exitCode === null
+      ) {
+        started2 = true;
+      }
+      if (started1 && started2) {
         console.log(
-          'Toolbox server process appears to be running. Polling for stability...',
+          'Both Toolbox servers started successfully (processes are active).',
         );
-        await delay(SERVER_READY_POLL_INTERVAL_MS * 2);
-        if (serverProcess.exitCode === null) {
-          console.log(
-            'Toolbox server started successfully (process is active).',
-          );
-          started = true;
-          break;
-        } else {
-          console.log('Toolbox server process exited after initial start.');
-          break;
-        }
+        break;
       }
       await delay(SERVER_READY_POLL_INTERVAL_MS);
-      console.log('Checking if toolbox server is started...');
+      console.log('Checking if toolbox servers are started...');
     }
 
-    if (!started) {
-      if (serverProcess && !serverProcess.killed) {
-        serverProcess.kill('SIGTERM');
-      }
+    if (!started1 || !started2) {
+      if (serverProcess1 && !serverProcess1.killed)
+        serverProcess1.kill('SIGTERM');
+      if (serverProcess2 && !serverProcess2.killed)
+        serverProcess2.kill('SIGTERM');
       throw new Error(
-        `Toolbox server failed to start within ${SERVER_READY_TIMEOUT_MS / 1000} seconds.`,
+        `Toolbox servers failed to start within ${SERVER_READY_TIMEOUT_MS / 1000} seconds.`,
       );
     }
 
     console.log('Jest Global Setup: Completed successfully.');
   } catch (error) {
     console.error('Jest Global Setup Failed:', error);
-    // Attempt to kill server if it started partially
-    const serverProcess = (globalThis as CustomGlobal)
+    // Attempt to kill servers if they started partially
+    const serverProcess1 = (globalThis as CustomGlobal)
       .__TOOLBOX_SERVER_PROCESS__;
-    if (serverProcess && !serverProcess.killed) {
-      console.log('Attempting to terminate partially started server...');
-      serverProcess.kill('SIGKILL');
+    const serverProcess2 = (globalThis as CustomGlobal)
+      .__TOOLBOX_SERVER_PROCESS_2__;
+    if (serverProcess1 && !serverProcess1.killed) {
+      console.log('Attempting to terminate partially started server 1...');
+      serverProcess1.kill('SIGKILL');
+    }
+    if (serverProcess2 && !serverProcess2.killed) {
+      console.log('Attempting to terminate partially started server 2...');
+      serverProcess2.kill('SIGKILL');
     }
     // Clean up temp file if created
     const toolsFilePath = (globalThis as CustomGlobal).__TOOLS_FILE_PATH__;

--- a/packages/toolbox-adk/test/e2e/jest.globalTeardown.ts
+++ b/packages/toolbox-adk/test/e2e/jest.globalTeardown.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as fs from 'fs-extra';
+import {ChildProcess} from 'child_process';
 import {CustomGlobal} from './types.js';
 
 const SERVER_TERMINATE_TIMEOUT_MS = 10000; // 10 seconds
@@ -22,50 +23,67 @@ export default async function globalTeardown(): Promise<void> {
   (globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__ = true;
 
   const customGlobal = globalThis as CustomGlobal;
-  const serverProcess = customGlobal.__TOOLBOX_SERVER_PROCESS__;
+  const serverProcess1 = customGlobal.__TOOLBOX_SERVER_PROCESS__;
+  const serverProcess2 = customGlobal.__TOOLBOX_SERVER_PROCESS_2__;
   const toolsFilePath = customGlobal.__TOOLS_FILE_PATH__;
 
-  if (serverProcess && !serverProcess.killed) {
-    console.log('Stopping toolbox server process...');
-    serverProcess.kill('SIGTERM'); // Graceful termination
+  const killServer = async (
+    serverProcess: ChildProcess | undefined,
+    name: string,
+  ) => {
+    if (serverProcess && !serverProcess.killed) {
+      console.log(`Stopping toolbox server ${name} process...`);
+      serverProcess.kill('SIGTERM'); // Graceful termination
 
-    // Wait for the process to exit
-    const stopPromise = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        if (!serverProcess.killed) {
-          console.warn(
-            'Toolbox server did not terminate gracefully, sending SIGKILL.',
-          );
-          serverProcess.kill('SIGKILL');
-        }
-        // Resolve even if SIGKILL is needed, as we want teardown to finish
-        resolve();
-      }, SERVER_TERMINATE_TIMEOUT_MS);
+      // Wait for the process to exit
+      const stopPromise = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          if (!serverProcess.killed) {
+            console.warn(
+              `Toolbox server ${name} did not terminate gracefully, sending SIGKILL.`,
+            );
+            serverProcess.kill('SIGKILL');
+          }
+          // Resolve even if SIGKILL is needed, as we want teardown to finish
+          resolve();
+        }, SERVER_TERMINATE_TIMEOUT_MS);
 
-      serverProcess.on('exit', (code, signal) => {
-        clearTimeout(timeout);
-        console.log(
-          `Toolbox server process exited with code ${code}, signal ${signal} during teardown.`,
+        serverProcess.on(
+          'exit',
+          (code: number | null, signal: NodeJS.Signals | null) => {
+            clearTimeout(timeout);
+            console.log(
+              `Toolbox server ${name} process exited with code ${code}, signal ${signal} during teardown.`,
+            );
+            resolve();
+          },
         );
-        resolve();
+        serverProcess.on('error', (err: Error) => {
+          // Should not happen if already running
+          clearTimeout(timeout);
+          console.error(
+            `Error during server ${name} process termination:`,
+            err,
+          );
+          reject(err);
+        });
       });
-      serverProcess.on('error', err => {
-        // Should not happen if already running
-        clearTimeout(timeout);
-        console.error('Error during server process termination:', err);
-        reject(err);
-      });
-    });
 
-    try {
-      await stopPromise;
-    } catch (error) {
-      console.error('Error while waiting for server to stop:', error);
-      if (!serverProcess.killed) serverProcess.kill('SIGKILL'); // Ensure it's killed
+      try {
+        await stopPromise;
+      } catch (error) {
+        console.error(`Error while waiting for server ${name} to stop:`, error);
+        if (!serverProcess.killed) serverProcess.kill('SIGKILL'); // Ensure it's killed
+      }
+    } else {
+      console.log(
+        `Toolbox server ${name} process was not running or already handled.`,
+      );
     }
-  } else {
-    console.log('Toolbox server process was not running or already handled.');
-  }
+  };
+
+  await killServer(serverProcess1, '1');
+  await killServer(serverProcess2, '2');
 
   if (toolsFilePath) {
     try {
@@ -79,6 +97,7 @@ export default async function globalTeardown(): Promise<void> {
     }
   }
   customGlobal.__TOOLBOX_SERVER_PROCESS__ = undefined;
+  customGlobal.__TOOLBOX_SERVER_PROCESS_2__ = undefined;
   customGlobal.__TOOLS_FILE_PATH__ = undefined;
   customGlobal.__GOOGLE_CLOUD_PROJECT__ = undefined;
 

--- a/packages/toolbox-adk/test/e2e/test.e2e.ts
+++ b/packages/toolbox-adk/test/e2e/test.e2e.ts
@@ -24,356 +24,364 @@ import {Context} from '@google/adk';
 
 import {authTokenGetter} from './utils.js';
 
-describe('ToolboxClient E2E Tests', () => {
-  let commonToolboxClient: ToolboxClient;
-  let getNRowsTool: ToolboxTool;
-  const testBaseUrl = 'http://localhost:5000';
-  const projectId = (globalThis as CustomGlobal).__GOOGLE_CLOUD_PROJECT__;
+const testBaseUrls = ['http://localhost:5000', 'http://localhost:5001'];
 
-  const mockContext = {} as Context;
+testBaseUrls.forEach(testBaseUrl => {
+  describe(`ToolboxClient E2E Tests against ${testBaseUrl}`, () => {
+    let commonToolboxClient: ToolboxClient;
+    let getNRowsTool: ToolboxTool;
+    const projectId = (globalThis as CustomGlobal).__GOOGLE_CLOUD_PROJECT__;
 
-  beforeAll(async () => {
-    commonToolboxClient = new ToolboxClient(
-      testBaseUrl,
-      undefined,
-      undefined,
-      Protocol.MCP,
-    );
-  });
+    const mockContext = {} as Context;
 
-  beforeEach(async () => {
-    getNRowsTool = await commonToolboxClient.loadTool('get-n-rows');
-    expect(getNRowsTool.name).toBe('get-n-rows');
-  });
-
-  describe('invokeTool', () => {
-    it('should invoke the getNRowsTool', async () => {
-      const response = await getNRowsTool.runAsync({
-        args: {num_rows: '2'},
-        toolContext: mockContext,
-      });
-      expect(typeof response).toBe('string');
-      expect(response).toContain('row1');
-      expect(response).toContain('row2');
-      expect(response).not.toContain('row3');
-    });
-
-    it('should invoke the getNRowsTool with missing params', async () => {
-      await expect(
-        getNRowsTool.runAsync({args: {}, toolContext: mockContext}),
-      ).rejects.toThrow(
-        /Argument validation failed for tool "get-n-rows":\s*- num_rows: Required/,
+    beforeAll(async () => {
+      commonToolboxClient = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP,
       );
     });
 
-    it('should invoke the getNRowsTool with wrong param type', async () => {
-      await expect(
-        getNRowsTool.runAsync({
-          args: {num_rows: 2},
+    beforeEach(async () => {
+      getNRowsTool = await commonToolboxClient.loadTool('get-n-rows');
+      expect(getNRowsTool.name).toBe('get-n-rows');
+    });
+
+    describe('invokeTool', () => {
+      it('should invoke the getNRowsTool', async () => {
+        const response = await getNRowsTool.runAsync({
+          args: {num_rows: '2'},
           toolContext: mockContext,
-        }),
-      ).rejects.toThrow(
-        /Argument validation failed for tool "get-n-rows":\s*- num_rows: Expected string, received number/,
-      );
-    });
-  });
+        });
+        expect(typeof response).toBe('string');
+        expect(response).toContain('row1');
+        expect(response).toContain('row2');
+        expect(response).not.toContain('row3');
+      });
 
-  describe('loadToolset', () => {
-    const specificToolsetTestCases = [
-      {
-        name: 'my-toolset',
-        expectedLength: 1,
-        expectedTools: ['get-row-by-id'],
-      },
-      {
-        name: 'my-toolset-2',
-        expectedLength: 2,
-        expectedTools: ['get-n-rows', 'get-row-by-id'],
-      },
-    ];
-
-    specificToolsetTestCases.forEach(testCase => {
-      it(`should successfully load the specific toolset "${testCase.name}"`, async () => {
-        const loadedTools = await commonToolboxClient.loadToolset(
-          testCase.name,
+      it('should invoke the getNRowsTool with missing params', async () => {
+        await expect(
+          getNRowsTool.runAsync({args: {}, toolContext: mockContext}),
+        ).rejects.toThrow(
+          /Argument validation failed for tool "get-n-rows":\s*- num_rows: Required/,
         );
+      });
 
+      it('should invoke the getNRowsTool with wrong param type', async () => {
+        await expect(
+          getNRowsTool.runAsync({
+            args: {num_rows: 2},
+            toolContext: mockContext,
+          }),
+        ).rejects.toThrow(
+          /Argument validation failed for tool "get-n-rows":\s*- num_rows: Expected string, received number/,
+        );
+      });
+    });
+
+    describe('loadToolset', () => {
+      const specificToolsetTestCases = [
+        {
+          name: 'my-toolset',
+          expectedLength: 1,
+          expectedTools: ['get-row-by-id'],
+        },
+        {
+          name: 'my-toolset-2',
+          expectedLength: 2,
+          expectedTools: ['get-n-rows', 'get-row-by-id'],
+        },
+      ];
+
+      specificToolsetTestCases.forEach(testCase => {
+        it(`should successfully load the specific toolset "${testCase.name}"`, async () => {
+          const loadedTools = await commonToolboxClient.loadToolset(
+            testCase.name,
+          );
+
+          expect(Array.isArray(loadedTools)).toBe(true);
+          expect(loadedTools.length).toBe(testCase.expectedLength);
+
+          const loadedToolNames = new Set(
+            loadedTools.map((tool: ToolboxTool) => tool.name),
+          );
+          expect(loadedToolNames).toEqual(new Set(testCase.expectedTools));
+
+          for (const tool of loadedTools) {
+            expect(typeof tool).toBe('object');
+            expect(tool).toBeInstanceOf(ToolboxTool);
+
+            expect(tool).toBeInstanceOf(ToolboxTool);
+            const declaration = tool._getDeclaration();
+            expect(declaration).toBeDefined();
+
+            expect(testCase.expectedTools).toContain(declaration!.name);
+            expect(declaration!.parameters).toBeDefined();
+          }
+        });
+      });
+
+      it('should successfully load the default toolset (all tools)', async () => {
+        const loadedTools = await commonToolboxClient.loadToolset(); // Load the default toolset (no name provided)
         expect(Array.isArray(loadedTools)).toBe(true);
-        expect(loadedTools.length).toBe(testCase.expectedLength);
+        expect(loadedTools.length).toBeGreaterThan(0);
+        const getNRowsToolFromSet = loadedTools.find(
+          (tool: ToolboxTool) => tool.name === 'get-n-rows',
+        ) as ToolboxTool;
+
+        expect(getNRowsToolFromSet).toBeDefined();
+        const declaration = getNRowsToolFromSet._getDeclaration();
+        expect(declaration).toBeDefined();
+        expect(declaration?.name).toBe('get-n-rows');
+        expect(declaration?.parameters).toBeDefined();
 
         const loadedToolNames = new Set(
           loadedTools.map((tool: ToolboxTool) => tool.name),
         );
-        expect(loadedToolNames).toEqual(new Set(testCase.expectedTools));
+        const expectedDefaultTools = new Set([
+          'get-row-by-content-auth',
+          'get-row-by-email-auth',
+          'get-row-by-id-auth',
+          'get-row-by-id',
+          'get-n-rows',
+          'search-rows',
+          'process-data',
+        ]);
+        expect(loadedToolNames).toEqual(expectedDefaultTools);
+      });
 
-        for (const tool of loadedTools) {
-          expect(typeof tool).toBe('object');
-          expect(tool).toBeInstanceOf(ToolboxTool);
+      it('should throw an error when trying to load a non-existent toolset', async () => {
+        await expect(
+          commonToolboxClient.loadToolset('non-existent-toolset'),
+        ).rejects.toThrow(
+          'MCP request failed with code -32600: toolset does not exist',
+        );
+      });
+    });
 
-          expect(tool).toBeInstanceOf(ToolboxTool);
-          const declaration = tool._getDeclaration();
-          expect(declaration).toBeDefined();
+    describe('bindParams', () => {
+      it('should successfully bind a parameter with bindParam and invoke', async () => {
+        const newTool = getNRowsTool.bindParam('num_rows', '3');
+        const response = await newTool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        }); // Invoke with no args
+        expect(response).toContain('row1');
+        expect(response).toContain('row2');
+        expect(response).toContain('row3');
+        expect(response).not.toContain('row4');
+      });
 
-          expect(testCase.expectedTools).toContain(declaration!.name);
-          expect(declaration!.parameters).toBeDefined();
+      it('should successfully bind parameters with bindParams and invoke', async () => {
+        const newTool = getNRowsTool.bindParams({num_rows: '3'});
+        const response = await newTool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        }); // Invoke with no args
+        expect(response).toContain('row1');
+        expect(response).toContain('row2');
+        expect(response).toContain('row3');
+        expect(response).not.toContain('row4');
+      });
+
+      it('should successfully bind a synchronous function value', async () => {
+        const newTool = getNRowsTool.bindParams({num_rows: () => '1'});
+        const response = await newTool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        });
+        expect(response).toContain('row1');
+        expect(response).not.toContain('row2');
+      });
+
+      it('should successfully bind an asynchronous function value', async () => {
+        const asyncNumProvider = async () => {
+          await new Promise(resolve => setTimeout(resolve, 10));
+          return '1';
+        };
+
+        const newTool = getNRowsTool.bindParams({num_rows: asyncNumProvider});
+        const response = await newTool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        });
+        expect(response).toContain('row1');
+        expect(response).not.toContain('row2');
+      });
+
+      it('should successfully bind parameters at load time', async () => {
+        const tool = await commonToolboxClient.loadTool('get-n-rows', null, {
+          num_rows: '3',
+        });
+        const response = await tool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        });
+        expect(response).toContain('row1');
+        expect(response).toContain('row2');
+        expect(response).toContain('row3');
+        expect(response).not.toContain('row4');
+      });
+
+      it('should throw an error when re-binding an existing parameter', () => {
+        const newTool = getNRowsTool.bindParam('num_rows', '1');
+        expect(() => {
+          newTool.bindParam('num_rows', '2');
+        }).toThrow(
+          "Cannot re-bind parameter: parameter 'num_rows' is already bound in tool 'get-n-rows'.",
+        );
+      });
+
+      it('should throw an error when binding a non-existent parameter', () => {
+        expect(() => {
+          getNRowsTool.bindParam('non_existent_param', '2');
+        }).toThrow(
+          "Unable to bind parameter: no parameter named 'non_existent_param' in tool 'get-n-rows'.",
+        );
+      });
+    });
+
+    describe('Auth E2E Tests', () => {
+      let authToken1: string;
+      let authToken2: string;
+      let authToken1Getter: () => string;
+      let authToken2Getter: () => string;
+
+      beforeAll(async () => {
+        if (!projectId) {
+          throw new Error(
+            'GOOGLE_CLOUD_PROJECT is not defined. Cannot run Auth E2E tests.',
+          );
+        }
+        authToken1 = await authTokenGetter(projectId, 'sdk_testing_client1');
+        authToken2 = await authTokenGetter(projectId, 'sdk_testing_client2');
+
+        authToken1Getter = () => authToken1;
+        authToken2Getter = () => authToken2;
+      });
+
+      it('should fail when running a tool that does not require auth with auth provided', async () => {
+        await expect(
+          commonToolboxClient.loadTool('get-row-by-id', {
+            'my-test-auth': authToken2Getter,
+          }),
+        ).rejects.toThrow(
+          "Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
+        );
+      });
+
+      it('should fail when running a tool requiring auth without providing auth', async () => {
+        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
+        await expect(
+          tool.runAsync({args: {id: '2'}, toolContext: mockContext}),
+        ).rejects.toThrow(
+          'One or more of the following authn services are required to invoke this tool: my-test-auth',
+        );
+      });
+
+      it('should fail when running a tool with incorrect auth', async () => {
+        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
+        const authTool = tool.addAuthTokenGetters({
+          'my-test-auth': authToken2Getter,
+        });
+        try {
+          await authTool.runAsync({
+            args: {id: '2'},
+            toolContext: mockContext,
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(AxiosError);
+          const axiosError = error as AxiosError;
+          expect(axiosError.response?.data).toEqual(
+            expect.objectContaining({
+              error: expect.objectContaining({
+                message: expect.stringContaining('unauthorized Tool call'),
+              }),
+            }),
+          );
         }
       });
-    });
 
-    it('should successfully load the default toolset (all tools)', async () => {
-      const loadedTools = await commonToolboxClient.loadToolset(); // Load the default toolset (no name provided)
-      expect(Array.isArray(loadedTools)).toBe(true);
-      expect(loadedTools.length).toBeGreaterThan(0);
-      const getNRowsToolFromSet = loadedTools.find(
-        (tool: ToolboxTool) => tool.name === 'get-n-rows',
-      ) as ToolboxTool;
-
-      expect(getNRowsToolFromSet).toBeDefined();
-      const declaration = getNRowsToolFromSet._getDeclaration();
-      expect(declaration).toBeDefined();
-      expect(declaration?.name).toBe('get-n-rows');
-      expect(declaration?.parameters).toBeDefined();
-
-      const loadedToolNames = new Set(
-        loadedTools.map((tool: ToolboxTool) => tool.name),
-      );
-      const expectedDefaultTools = new Set([
-        'get-row-by-content-auth',
-        'get-row-by-email-auth',
-        'get-row-by-id-auth',
-        'get-row-by-id',
-        'get-n-rows',
-        'search-rows',
-        'process-data',
-      ]);
-      expect(loadedToolNames).toEqual(expectedDefaultTools);
-    });
-
-    it('should throw an error when trying to load a non-existent toolset', async () => {
-      await expect(
-        commonToolboxClient.loadToolset('non-existent-toolset'),
-      ).rejects.toThrow(
-        'MCP request failed with code -32600: toolset does not exist',
-      );
-    });
-  });
-
-  describe('bindParams', () => {
-    it('should successfully bind a parameter with bindParam and invoke', async () => {
-      const newTool = getNRowsTool.bindParam('num_rows', '3');
-      const response = await newTool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      }); // Invoke with no args
-      expect(response).toContain('row1');
-      expect(response).toContain('row2');
-      expect(response).toContain('row3');
-      expect(response).not.toContain('row4');
-    });
-
-    it('should successfully bind parameters with bindParams and invoke', async () => {
-      const newTool = getNRowsTool.bindParams({num_rows: '3'});
-      const response = await newTool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      }); // Invoke with no args
-      expect(response).toContain('row1');
-      expect(response).toContain('row2');
-      expect(response).toContain('row3');
-      expect(response).not.toContain('row4');
-    });
-
-    it('should successfully bind a synchronous function value', async () => {
-      const newTool = getNRowsTool.bindParams({num_rows: () => '1'});
-      const response = await newTool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row1');
-      expect(response).not.toContain('row2');
-    });
-
-    it('should successfully bind an asynchronous function value', async () => {
-      const asyncNumProvider = async () => {
-        await new Promise(resolve => setTimeout(resolve, 10));
-        return '1';
-      };
-
-      const newTool = getNRowsTool.bindParams({num_rows: asyncNumProvider});
-      const response = await newTool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row1');
-      expect(response).not.toContain('row2');
-    });
-
-    it('should successfully bind parameters at load time', async () => {
-      const tool = await commonToolboxClient.loadTool('get-n-rows', null, {
-        num_rows: '3',
-      });
-      const response = await tool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row1');
-      expect(response).toContain('row2');
-      expect(response).toContain('row3');
-      expect(response).not.toContain('row4');
-    });
-
-    it('should throw an error when re-binding an existing parameter', () => {
-      const newTool = getNRowsTool.bindParam('num_rows', '1');
-      expect(() => {
-        newTool.bindParam('num_rows', '2');
-      }).toThrow(
-        "Cannot re-bind parameter: parameter 'num_rows' is already bound in tool 'get-n-rows'.",
-      );
-    });
-
-    it('should throw an error when binding a non-existent parameter', () => {
-      expect(() => {
-        getNRowsTool.bindParam('non_existent_param', '2');
-      }).toThrow(
-        "Unable to bind parameter: no parameter named 'non_existent_param' in tool 'get-n-rows'.",
-      );
-    });
-  });
-
-  describe('Auth E2E Tests', () => {
-    let authToken1: string;
-    let authToken2: string;
-    let authToken1Getter: () => string;
-    let authToken2Getter: () => string;
-
-    beforeAll(async () => {
-      if (!projectId) {
-        throw new Error(
-          'GOOGLE_CLOUD_PROJECT is not defined. Cannot run Auth E2E tests.',
-        );
-      }
-      authToken1 = await authTokenGetter(projectId, 'sdk_testing_client1');
-      authToken2 = await authTokenGetter(projectId, 'sdk_testing_client2');
-
-      authToken1Getter = () => authToken1;
-      authToken2Getter = () => authToken2;
-    });
-
-    it('should fail when running a tool that does not require auth with auth provided', async () => {
-      await expect(
-        commonToolboxClient.loadTool('get-row-by-id', {
-          'my-test-auth': authToken2Getter,
-        }),
-      ).rejects.toThrow(
-        "Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
-      );
-    });
-
-    it('should fail when running a tool requiring auth without providing auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-      await expect(
-        tool.runAsync({args: {id: '2'}, toolContext: mockContext}),
-      ).rejects.toThrow(
-        'One or more of the following authn services are required to invoke this tool: my-test-auth',
-      );
-    });
-
-    it('should fail when running a tool with incorrect auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-      const authTool = tool.addAuthTokenGetters({
-        'my-test-auth': authToken2Getter,
-      });
-      try {
-        await authTool.runAsync({
+      it('should succeed when running a tool with correct auth', async () => {
+        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
+        const authTool = tool.addAuthTokenGetters({
+          'my-test-auth': authToken1Getter,
+        });
+        const response = await authTool.runAsync({
           args: {id: '2'},
           toolContext: mockContext,
         });
-      } catch (error) {
-        expect(error).toBeInstanceOf(AxiosError);
-        const axiosError = error as AxiosError;
-        expect(axiosError.response?.data).toEqual(
-          expect.objectContaining({
-            error: expect.objectContaining({
-              message: expect.stringContaining('unauthorized Tool call'),
-            }),
-          }),
+        expect(response).toContain('row2');
+      });
+
+      it('should succeed when running a tool with correct async auth', async () => {
+        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
+        const getAsyncToken = async () => {
+          return authToken1Getter();
+        };
+        const authTool = tool.addAuthTokenGetters({
+          'my-test-auth': getAsyncToken,
+        });
+        const response = await authTool.runAsync({
+          args: {id: '2'},
+          toolContext: mockContext,
+        });
+        expect(response).toContain('row2');
+      });
+
+      it('should fail when a tool with a param requiring auth is run without auth', async () => {
+        const tool = await commonToolboxClient.loadTool(
+          'get-row-by-email-auth',
         );
-      }
-    });
-
-    it('should succeed when running a tool with correct auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-      const authTool = tool.addAuthTokenGetters({
-        'my-test-auth': authToken1Getter,
-      });
-      const response = await authTool.runAsync({
-        args: {id: '2'},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row2');
-    });
-
-    it('should succeed when running a tool with correct async auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-      const getAsyncToken = async () => {
-        return authToken1Getter();
-      };
-      const authTool = tool.addAuthTokenGetters({
-        'my-test-auth': getAsyncToken,
-      });
-      const response = await authTool.runAsync({
-        args: {id: '2'},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row2');
-    });
-
-    it('should fail when a tool with a param requiring auth is run without auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-email-auth');
-      await expect(
-        tool.runAsync({args: {}, toolContext: mockContext}),
-      ).rejects.toThrow(
-        'One or more of the following authn services are required to invoke this tool: my-test-auth',
-      );
-    });
-
-    it('should succeed when a tool with a param requiring auth is run with correct auth', async () => {
-      const tool = await commonToolboxClient.loadTool('get-row-by-email-auth', {
-        'my-test-auth': authToken1Getter,
-      });
-      const response = await tool.runAsync({
-        args: {},
-        toolContext: mockContext,
-      });
-      expect(response).toContain('row4');
-      expect(response).toContain('row5');
-      expect(response).toContain('row6');
-    });
-
-    it('should fail when a tool with a param requiring auth is run with insufficient auth claims', async () => {
-      expect.assertions(3);
-
-      const tool = await commonToolboxClient.loadTool(
-        'get-row-by-content-auth',
-        {
-          'my-test-auth': authToken1Getter,
-        },
-      );
-      try {
-        await tool.runAsync({args: {}, toolContext: mockContext});
-      } catch (error) {
-        expect(error).toBeInstanceOf(AxiosError);
-        const axiosError = error as AxiosError;
-        expect(axiosError.response?.data).toEqual(
-          expect.objectContaining({
-            error: expect.objectContaining({
-              message: expect.stringContaining(
-                'provided parameters were invalid',
-              ),
-            }),
-          }),
+        await expect(
+          tool.runAsync({args: {}, toolContext: mockContext}),
+        ).rejects.toThrow(
+          'One or more of the following authn services are required to invoke this tool: my-test-auth',
         );
-      }
+      });
+
+      it('should succeed when a tool with a param requiring auth is run with correct auth', async () => {
+        const tool = await commonToolboxClient.loadTool(
+          'get-row-by-email-auth',
+          {
+            'my-test-auth': authToken1Getter,
+          },
+        );
+        const response = await tool.runAsync({
+          args: {},
+          toolContext: mockContext,
+        });
+        expect(response).toContain('row4');
+        expect(response).toContain('row5');
+        expect(response).toContain('row6');
+      });
+
+      it('should fail when a tool with a param requiring auth is run with insufficient auth claims', async () => {
+        expect.assertions(3);
+
+        const tool = await commonToolboxClient.loadTool(
+          'get-row-by-content-auth',
+          {
+            'my-test-auth': authToken1Getter,
+          },
+        );
+        try {
+          await tool.runAsync({args: {}, toolContext: mockContext});
+        } catch (error) {
+          expect(error).toBeInstanceOf(AxiosError);
+          const axiosError = error as AxiosError;
+          expect(axiosError.response?.data).toEqual(
+            expect.objectContaining({
+              error: expect.objectContaining({
+                message: expect.stringContaining(
+                  'provided parameters were invalid',
+                ),
+              }),
+            }),
+          );
+        }
+      });
     });
   });
 });

--- a/packages/toolbox-adk/test/e2e/test.e2e.ts
+++ b/packages/toolbox-adk/test/e2e/test.e2e.ts
@@ -151,6 +151,18 @@ testBaseUrls.forEach(testBaseUrl => {
         expect(loadedToolNames).toEqual(expectedDefaultTools);
       });
 
+      it('should successfully load the toolset with an explicit protocol', async () => {
+        const explicitClient = new ToolboxClient(
+          testBaseUrl,
+          undefined,
+          undefined,
+          Protocol.MCP_v20251125,
+        );
+        const loadedTools = await explicitClient.loadToolset();
+        expect(Array.isArray(loadedTools)).toBe(true);
+        expect(loadedTools.length).toBeGreaterThan(0);
+      });
+
       it('should throw an error when trying to load a non-existent toolset', async () => {
         await expect(
           commonToolboxClient.loadToolset('non-existent-toolset'),

--- a/packages/toolbox-adk/test/e2e/types.ts
+++ b/packages/toolbox-adk/test/e2e/types.ts
@@ -18,6 +18,7 @@ import {ChildProcess} from 'child_process';
 export type CustomGlobal = typeof globalThis & {
   __TOOLS_FILE_PATH__?: string;
   __TOOLBOX_SERVER_PROCESS__?: ChildProcess;
+  __TOOLBOX_SERVER_PROCESS_2__?: ChildProcess;
   __SERVER_TEARDOWN_INITIATED__?: boolean;
   __GOOGLE_CLOUD_PROJECT__?: string;
 };

--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -27,6 +27,8 @@ import {McpHttpTransportV20241105} from './mcp/v20241105/mcp.js';
 import {McpHttpTransportV20250618} from './mcp/v20250618/mcp.js';
 import {McpHttpTransportV20250326} from './mcp/v20250326/mcp.js';
 import {McpHttpTransportV20251125} from './mcp/v20251125/mcp.js';
+import {McpHttpTransportV20260618} from './mcp/v20260618/mcp.js';
+import {ProtocolNegotiationError} from './errorUtils.js';
 import {
   BoundParams,
   identifyAuthRequirements,
@@ -49,6 +51,8 @@ export type ClientHeadersConfig = Record<string, ClientHeaderProvider>;
 class ToolboxClient {
   #transport: ITransport;
   #clientHeaders: ClientHeadersConfig;
+  #session: AxiosInstance | undefined;
+  #baseUrl: string;
 
   /**
    * Initializes the ToolboxClient.
@@ -68,7 +72,9 @@ class ToolboxClient {
     clientName?: string,
     clientVersion?: string,
   ) {
+    this.#baseUrl = url;
     this.#clientHeaders = clientHeaders || {};
+    this.#session = session || undefined;
     warnIfHttpAndHeaders(url, this.#clientHeaders);
     if (!getSupportedMcpVersions().includes(protocol)) {
       throw new Error(`Unsupported protocol version: ${protocol}`);
@@ -80,43 +86,63 @@ class ToolboxClient {
       );
     }
 
+    this.#transport = this.#createTransport(
+      url,
+      session || undefined,
+      protocol,
+      clientName,
+      clientVersion,
+    );
+  }
+
+  #createTransport(
+    url: string,
+    session: AxiosInstance | undefined,
+    protocol: Protocol,
+    clientName?: string,
+    clientVersion?: string,
+  ): ITransport {
     switch (protocol) {
       case Protocol.MCP_v20241105:
-        this.#transport = new McpHttpTransportV20241105(
+        return new McpHttpTransportV20241105(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20250326:
-        this.#transport = new McpHttpTransportV20250326(
+        return new McpHttpTransportV20250326(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20250618:
-        this.#transport = new McpHttpTransportV20250618(
+        return new McpHttpTransportV20250618(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
       case Protocol.MCP_v20251125:
-        this.#transport = new McpHttpTransportV20251125(
+        return new McpHttpTransportV20251125(
           url,
-          session || undefined,
+          session,
           protocol,
           clientName,
           clientVersion,
         );
-        break;
+      case Protocol.MCP_DRAFT_2026_v1:
+        return new McpHttpTransportV20260618(
+          url,
+          session,
+          protocol,
+          clientName,
+          clientVersion,
+        );
       default:
         throw new Error(`Unsupported MCP protocol version: ${protocol}`);
     }
@@ -214,7 +240,21 @@ class ToolboxClient {
   ): Promise<ToolboxTool> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const headers = await this.#resolveClientHeaders();
-    const manifest = await this.#transport.toolGet(name, headers);
+    let manifest;
+    try {
+      manifest = await this.#transport.toolGet(name, headers);
+    } catch (e: unknown) {
+      if (e instanceof ProtocolNegotiationError) {
+        this.#transport = this.#createTransport(
+          this.#baseUrl,
+          this.#session,
+          e.fallbackVersion,
+        );
+        manifest = await this.#transport.toolGet(name, headers);
+      } else {
+        throw e;
+      }
+    }
 
     if (
       manifest.tools &&
@@ -285,7 +325,21 @@ class ToolboxClient {
     const toolsetName = name || '';
     const headers = await this.#resolveClientHeaders();
 
-    const manifest = await this.#transport.toolsList(toolsetName, headers);
+    let manifest;
+    try {
+      manifest = await this.#transport.toolsList(toolsetName, headers);
+    } catch (e: unknown) {
+      if (e instanceof ProtocolNegotiationError) {
+        this.#transport = this.#createTransport(
+          this.#baseUrl,
+          this.#session,
+          e.fallbackVersion,
+        );
+        manifest = await this.#transport.toolsList(toolsetName, headers);
+      } else {
+        throw e;
+      }
+    }
     const tools: ToolboxTool[] = [];
 
     const overallUsedAuthKeys: Set<string> = new Set();

--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -21,7 +21,6 @@ import {
   ZodManifestSchema,
   Protocol,
   getSupportedMcpVersions,
-  MCP_LATEST,
 } from './protocol.js';
 import {McpHttpTransportV20241105} from './mcp/v20241105/mcp.js';
 import {McpHttpTransportV20250618} from './mcp/v20250618/mcp.js';
@@ -78,12 +77,6 @@ class ToolboxClient {
     warnIfHttpAndHeaders(url, this.#clientHeaders);
     if (!getSupportedMcpVersions().includes(protocol)) {
       throw new Error(`Unsupported protocol version: ${protocol}`);
-    }
-
-    if (protocol !== MCP_LATEST) {
-      console.warn(
-        `A newer version of MCP: ${MCP_LATEST} is available. Please use the latest version ${MCP_LATEST} to use the latest features.`,
-      );
     }
 
     this.#transport = this.#createTransport(

--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -54,6 +54,12 @@ class ToolboxClient {
   #baseUrl: string;
 
   /**
+   * The negotiated protocol version currently in use.
+   */
+  get protocolVersion(): Protocol {
+    return this.#transport.protocolVersion as Protocol;
+  }
+  /**
    * Initializes the ToolboxClient.
    * @param {string} url - The base URL for the Toolbox service API (e.g., "http://localhost:5000").
    * @param {AxiosInstance} [session] - Optional Axios instance for making HTTP

--- a/packages/toolbox-core/src/toolbox_core/client.ts
+++ b/packages/toolbox-core/src/toolbox_core/client.ts
@@ -52,6 +52,7 @@ class ToolboxClient {
   #clientHeaders: ClientHeadersConfig;
   #session: AxiosInstance | undefined;
   #baseUrl: string;
+  #supportedProtocols: string[];
 
   /**
    * The negotiated protocol version currently in use.
@@ -73,7 +74,7 @@ class ToolboxClient {
     url: string,
     session?: AxiosInstance | null,
     clientHeaders?: ClientHeadersConfig | null,
-    protocol: Protocol = Protocol.MCP,
+    protocol: Protocol | Protocol[] | string[] | string = Protocol.MCP,
     clientName?: string,
     clientVersion?: string,
   ) {
@@ -81,14 +82,47 @@ class ToolboxClient {
     this.#clientHeaders = clientHeaders || {};
     this.#session = session || undefined;
     warnIfHttpAndHeaders(url, this.#clientHeaders);
-    if (!getSupportedMcpVersions().includes(protocol)) {
-      throw new Error(`Unsupported protocol version: ${protocol}`);
+
+    let initialProtocol: Protocol;
+    if (Array.isArray(protocol)) {
+      if (protocol.length === 0) {
+        throw new Error('Protocol array cannot be empty');
+      }
+
+      const globalSupported = getSupportedMcpVersions();
+
+      for (const p of protocol) {
+        if (!globalSupported.includes(p as Protocol)) {
+          throw new Error(
+            `Invalid protocol version '${p}'. Must be one of: ${globalSupported.join(', ')}`,
+          );
+        }
+      }
+
+      const requestedSet = new Set<string>(protocol);
+      const sorted = globalSupported.filter(globalVer =>
+        requestedSet.has(globalVer),
+      );
+
+      if (sorted.length === 0) {
+        throw new Error('None of the provided protocols are supported');
+      }
+
+      this.#supportedProtocols = sorted;
+      initialProtocol = sorted[0] as Protocol; // Start with the highest requested version
+    } else {
+      initialProtocol = protocol as Protocol;
+      const globalSupported = getSupportedMcpVersions();
+      if (!globalSupported.includes(initialProtocol)) {
+        throw new Error(`Invalid protocol version '${initialProtocol}'`);
+      }
+      this.#supportedProtocols = globalSupported;
     }
 
-    this.#transport = this.#createTransport(
+    this.#transport = this.#createTransportWithProtocols(
       url,
       session || undefined,
-      protocol,
+      initialProtocol,
       clientName,
       clientVersion,
     );
@@ -145,6 +179,26 @@ class ToolboxClient {
       default:
         throw new Error(`Unsupported MCP protocol version: ${protocol}`);
     }
+  }
+
+  #createTransportWithProtocols(
+    url: string,
+    session: AxiosInstance | undefined,
+    protocol: Protocol,
+    clientName?: string,
+    clientVersion?: string,
+  ): ITransport {
+    const transport = this.#createTransport(
+      url,
+      session,
+      protocol,
+      clientName,
+      clientVersion,
+    );
+    if (this.#supportedProtocols) {
+      transport.supportedProtocols = this.#supportedProtocols;
+    }
+    return transport;
   }
 
   /**
@@ -218,6 +272,49 @@ class ToolboxClient {
     return {tool, usedAuthKeys, usedBoundKeys};
   }
 
+  async #executeWithFallback<T>(action: () => Promise<T>): Promise<T> {
+    while (true) {
+      try {
+        return await action();
+      } catch (e: unknown) {
+        if (e instanceof ProtocolNegotiationError) {
+          const serverVersion = e.fallbackVersion as string;
+          let mutuallySupported: string[] | null = null;
+
+          if (this.#supportedProtocols.includes(serverVersion as Protocol)) {
+            mutuallySupported = [serverVersion];
+          } else {
+            const allVersions = getSupportedMcpVersions();
+            if (allVersions.includes(serverVersion as Protocol)) {
+              const idx = allVersions.indexOf(serverVersion as Protocol);
+              const serverSupported = allVersions.slice(idx);
+              mutuallySupported = this.#supportedProtocols.filter(v =>
+                serverSupported.includes(v as Protocol),
+              );
+            }
+          }
+
+          if (!mutuallySupported || mutuallySupported.length === 0) {
+            throw new Error('No mutually supported protocol version');
+          }
+
+          const fallbackProtocol = mutuallySupported[0] as Protocol;
+          if (fallbackProtocol === this.#transport.protocolVersion) {
+            throw e;
+          }
+
+          this.#transport = this.#createTransportWithProtocols(
+            this.#baseUrl,
+            this.#session,
+            fallbackProtocol,
+          );
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
   /**
    * Asynchronously loads a tool from the server.
    * Retrieves the schema for the specified tool from the Toolbox server and
@@ -239,21 +336,9 @@ class ToolboxClient {
   ): Promise<ToolboxTool> {
     warnIfHttpAndHeaders(this.#transport.baseUrl, authTokenGetters);
     const headers = await this.#resolveClientHeaders();
-    let manifest;
-    try {
-      manifest = await this.#transport.toolGet(name, headers);
-    } catch (e: unknown) {
-      if (e instanceof ProtocolNegotiationError) {
-        this.#transport = this.#createTransport(
-          this.#baseUrl,
-          this.#session,
-          e.fallbackVersion,
-        );
-        manifest = await this.#transport.toolGet(name, headers);
-      } else {
-        throw e;
-      }
-    }
+    const manifest = await this.#executeWithFallback(() =>
+      this.#transport.toolGet(name, headers),
+    );
 
     if (
       manifest.tools &&
@@ -324,21 +409,9 @@ class ToolboxClient {
     const toolsetName = name || '';
     const headers = await this.#resolveClientHeaders();
 
-    let manifest;
-    try {
-      manifest = await this.#transport.toolsList(toolsetName, headers);
-    } catch (e: unknown) {
-      if (e instanceof ProtocolNegotiationError) {
-        this.#transport = this.#createTransport(
-          this.#baseUrl,
-          this.#session,
-          e.fallbackVersion,
-        );
-        manifest = await this.#transport.toolsList(toolsetName, headers);
-      } else {
-        throw e;
-      }
-    }
+    const manifest = await this.#executeWithFallback(() =>
+      this.#transport.toolsList(toolsetName, headers),
+    );
     const tools: ToolboxTool[] = [];
 
     const overallUsedAuthKeys: Set<string> = new Set();

--- a/packages/toolbox-core/src/toolbox_core/errorUtils.ts
+++ b/packages/toolbox-core/src/toolbox_core/errorUtils.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {isAxiosError} from 'axios';
+import {Protocol} from './protocol.js';
 
 /**
  * Logs a standardized error message to the console, differentiating between
@@ -39,4 +40,14 @@ export function logApiError(baseMessage: string, error: unknown): void {
     loggableDetails = error; // Fallback for non-Error types or unknown errors
   }
   console.error(baseMessage, loggableDetails);
+}
+
+export class ProtocolNegotiationError extends Error {
+  fallbackVersion: Protocol;
+
+  constructor(fallbackVersion: Protocol) {
+    super(`Server requires protocol fallback to ${fallbackVersion}`);
+    this.name = 'ProtocolNegotiationError';
+    this.fallbackVersion = fallbackVersion;
+  }
 }

--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -45,6 +45,7 @@ export abstract class McpHttpTransportBase implements ITransport {
   protected _mcpBaseUrl: string;
   protected _protocolVersion: string;
   protected _serverVersion: string | null = null;
+  public supportedProtocols?: string[];
 
   protected _manageSession: boolean;
   protected _session: AxiosInstance;

--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -78,6 +78,10 @@ export abstract class McpHttpTransportBase implements ITransport {
     await this._initPromise;
   }
 
+  get protocolVersion(): string {
+    return this._protocolVersion;
+  }
+
   get baseUrl(): string {
     return this._mcpBaseUrl;
   }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
@@ -16,8 +16,8 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
-import {logApiError} from '../../errorUtils.js';
+import {ZodManifest, Protocol} from '../../protocol.js';
+import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
@@ -136,11 +136,7 @@ export class McpHttpTransportV20241105 extends McpHttpTransportBase {
     this._serverVersion = result.serverInfo.version;
 
     if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
+      throw new ProtocolNegotiationError(result.protocolVersion as Protocol);
     }
 
     if (!result.capabilities.tools) {

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
@@ -16,8 +16,8 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
-import {logApiError} from '../../errorUtils.js';
+import {ZodManifest, Protocol} from '../../protocol.js';
+import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
@@ -155,11 +155,7 @@ export class McpHttpTransportV20250326 extends McpHttpTransportBase {
     this._serverVersion = result.serverInfo.version;
 
     if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
+      throw new ProtocolNegotiationError(result.protocolVersion as Protocol);
     }
 
     if (!result.capabilities.tools) {

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -16,8 +16,12 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
-import {logApiError} from '../../errorUtils.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../protocol.js';
+import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
@@ -108,7 +112,62 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
       }
 
       return null;
-    } catch (error) {
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'isAxiosError' in error &&
+        (error as AxiosError).response?.status === 400 &&
+        (error as AxiosError).response?.data &&
+        typeof (error as AxiosError).response?.data === 'object' &&
+        'error' in
+          ((error as AxiosError).response?.data as Record<string, unknown>)
+      ) {
+        const errorData = (error as AxiosError).response?.data as Record<
+          string,
+          unknown
+        >;
+        const errObj = errorData.error;
+
+        if (
+          typeof errObj === 'string' &&
+          errObj.includes('invalid protocol version')
+        ) {
+          throw new ProtocolNegotiationError(Protocol.MCP_v20250326);
+        }
+
+        if (
+          typeof errObj === 'object' &&
+          errObj !== null &&
+          'code' in errObj &&
+          (errObj as Record<string, unknown>).code === -32004
+        ) {
+          const errData = (errObj as Record<string, unknown>).data;
+          if (
+            errData &&
+            typeof errData === 'object' &&
+            'supported' in errData
+          ) {
+            const supported = (errData as Record<string, unknown>).supported;
+            if (Array.isArray(supported) && supported.length > 0) {
+              let mutuallySupportedVersion: string | null = null;
+              for (const ourVer of getSupportedMcpVersions()) {
+                if (supported.includes(ourVer)) {
+                  mutuallySupportedVersion = ourVer;
+                  break;
+                }
+              }
+              if (mutuallySupportedVersion) {
+                throw new ProtocolNegotiationError(
+                  mutuallySupportedVersion as Protocol,
+                );
+              }
+              throw new ProtocolNegotiationError(supported[0] as Protocol);
+            }
+          }
+        }
+      }
+
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }
@@ -142,11 +201,7 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
     this._serverVersion = result.serverInfo.version;
 
     if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
+      throw new ProtocolNegotiationError(result.protocolVersion as Protocol);
     }
 
     if (!result.capabilities.tools) {

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -28,6 +28,68 @@ import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20250618 extends McpHttpTransportBase {
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022 or -32004)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
+    const isLegacyError =
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -81,7 +143,10 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -113,61 +178,20 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
 
       return null;
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'isAxiosError' in error &&
-        (error as AxiosError).response?.status === 400 &&
-        (error as AxiosError).response?.data &&
-        typeof (error as AxiosError).response?.data === 'object' &&
-        'error' in
-          ((error as AxiosError).response?.data as Record<string, unknown>)
-      ) {
-        const errorData = (error as AxiosError).response?.data as Record<
-          string,
-          unknown
-        >;
-        const errObj = errorData.error;
-
-        if (
-          typeof errObj === 'string' &&
-          errObj.includes('invalid protocol version')
-        ) {
-          throw new ProtocolNegotiationError(Protocol.MCP_v20250326);
-        }
-
-        if (
-          typeof errObj === 'object' &&
-          errObj !== null &&
-          'code' in errObj &&
-          (errObj as Record<string, unknown>).code === -32004
-        ) {
-          const errData = (errObj as Record<string, unknown>).data;
-          if (
-            errData &&
-            typeof errData === 'object' &&
-            'supported' in errData
-          ) {
-            const supported = (errData as Record<string, unknown>).supported;
-            if (Array.isArray(supported) && supported.length > 0) {
-              let mutuallySupportedVersion: string | null = null;
-              for (const ourVer of getSupportedMcpVersions()) {
-                if (supported.includes(ourVer)) {
-                  mutuallySupportedVersion = ourVer;
-                  break;
-                }
-              }
-              if (mutuallySupportedVersion) {
-                throw new ProtocolNegotiationError(
-                  mutuallySupportedVersion as Protocol,
-                );
-              }
-              throw new ProtocolNegotiationError(supported[0] as Protocol);
-            }
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
+      if (error && typeof error === 'object' && 'isAxiosError' in error) {
+        const jsonResp = (error as AxiosError).response?.data;
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
           }
         }
       }
-
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -51,7 +51,7 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
       };
     }
 
-    // Inject Protocol Version into headers (v2025-06-18 specific)
+    // Inject Protocol Version into headers as required by MCP spec
     const reqHeaders = {...(headers || {})};
     reqHeaders['MCP-Protocol-Version'] = this._protocolVersion;
 

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
@@ -16,8 +16,12 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
-import {logApiError} from '../../errorUtils.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../protocol.js';
+import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
@@ -108,7 +112,61 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
       }
 
       return null;
-    } catch (error) {
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'isAxiosError' in error &&
+        (error as AxiosError).response?.status === 400 &&
+        (error as AxiosError).response?.data &&
+        typeof (error as AxiosError).response?.data === 'object' &&
+        'error' in
+          ((error as AxiosError).response?.data as Record<string, unknown>)
+      ) {
+        const errorData = (error as AxiosError).response?.data as Record<
+          string,
+          unknown
+        >;
+        const errObj = errorData.error;
+
+        if (
+          typeof errObj === 'string' &&
+          errObj.includes('invalid protocol version')
+        ) {
+          throw new ProtocolNegotiationError(Protocol.MCP_v20250618);
+        }
+
+        if (
+          typeof errObj === 'object' &&
+          errObj !== null &&
+          'code' in errObj &&
+          (errObj as Record<string, unknown>).code === -32004
+        ) {
+          const errData = (errObj as Record<string, unknown>).data;
+          if (
+            errData &&
+            typeof errData === 'object' &&
+            'supported' in errData
+          ) {
+            const supported = (errData as Record<string, unknown>).supported;
+            if (Array.isArray(supported) && supported.length > 0) {
+              let mutuallySupportedVersion: string | null = null;
+              for (const ourVer of getSupportedMcpVersions()) {
+                if (supported.includes(ourVer)) {
+                  mutuallySupportedVersion = ourVer;
+                  break;
+                }
+              }
+              if (mutuallySupportedVersion) {
+                throw new ProtocolNegotiationError(
+                  mutuallySupportedVersion as Protocol,
+                );
+              }
+              throw new ProtocolNegotiationError(supported[0] as Protocol);
+            }
+          }
+        }
+      }
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }
@@ -142,11 +200,7 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     this._serverVersion = result.serverInfo.version;
 
     if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
+      throw new ProtocolNegotiationError(result.protocolVersion as Protocol);
     }
 
     if (!result.capabilities.tools) {

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
@@ -28,6 +28,68 @@ import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20251125 extends McpHttpTransportBase {
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022 or -32004)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
+    const isLegacyError =
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -81,7 +143,10 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -113,57 +178,17 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       return null;
     } catch (error: unknown) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'isAxiosError' in error &&
-        (error as AxiosError).response?.status === 400 &&
-        (error as AxiosError).response?.data &&
-        typeof (error as AxiosError).response?.data === 'object' &&
-        'error' in
-          ((error as AxiosError).response?.data as Record<string, unknown>)
-      ) {
-        const errorData = (error as AxiosError).response?.data as Record<
-          string,
-          unknown
-        >;
-        const errObj = errorData.error;
-
-        if (
-          typeof errObj === 'string' &&
-          errObj.includes('invalid protocol version')
-        ) {
-          throw new ProtocolNegotiationError(Protocol.MCP_v20250618);
-        }
-
-        if (
-          typeof errObj === 'object' &&
-          errObj !== null &&
-          'code' in errObj &&
-          (errObj as Record<string, unknown>).code === -32004
-        ) {
-          const errData = (errObj as Record<string, unknown>).data;
-          if (
-            errData &&
-            typeof errData === 'object' &&
-            'supported' in errData
-          ) {
-            const supported = (errData as Record<string, unknown>).supported;
-            if (Array.isArray(supported) && supported.length > 0) {
-              let mutuallySupportedVersion: string | null = null;
-              for (const ourVer of getSupportedMcpVersions()) {
-                if (supported.includes(ourVer)) {
-                  mutuallySupportedVersion = ourVer;
-                  break;
-                }
-              }
-              if (mutuallySupportedVersion) {
-                throw new ProtocolNegotiationError(
-                  mutuallySupportedVersion as Protocol,
-                );
-              }
-              throw new ProtocolNegotiationError(supported[0] as Protocol);
-            }
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
+      if (error && typeof error === 'object' && 'isAxiosError' in error) {
+        const jsonResp = (error as AxiosError).response?.data;
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
           }
         }
       }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -55,13 +55,14 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       const serverSupported = ((
         (errVal as Record<string, unknown>).data as Record<string, unknown>
       )?.supported || []) as string[];
-      const clientSupported = getSupportedMcpVersions();
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
       const mutuallySupported = clientSupported.filter(v =>
         serverSupported.includes(v),
       );
 
       if (mutuallySupported.length > 0) {
-        throw new ProtocolNegotiationError(mutuallySupported[0]);
+        throw new ProtocolNegotiationError(mutuallySupported[0] as Protocol);
       } else {
         throw new Error(
           `No mutually supported protocol version. Client supports: ${clientSupported.join(
@@ -85,12 +86,15 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
 
     if (isLegacyError) {
       // Cascading Fallback
-      const clientSupported = getSupportedMcpVersions();
+      const clientSupported =
+        this.supportedProtocols || getSupportedMcpVersions();
       const currentIdx = clientSupported.indexOf(
         this._protocolVersion as Protocol,
       );
       if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
-        throw new ProtocolNegotiationError(clientSupported[currentIdx + 1]);
+        throw new ProtocolNegotiationError(
+          clientSupported[currentIdx + 1] as Protocol,
+        );
       } else {
         throw new Error(
           "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
@@ -209,9 +213,13 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       }
       if (error instanceof AxiosError) {
         const jsonResp = error.response?.data;
-        if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
-          const errVal = (jsonResp as Record<string, unknown>).error;
-          this.#checkProtocolNegotiationError(errVal);
+        if (jsonResp) {
+          if (typeof jsonResp === 'object' && 'error' in jsonResp) {
+            const errVal = (jsonResp as Record<string, unknown>).error;
+            this.#checkProtocolNegotiationError(errVal);
+          } else if (typeof jsonResp === 'string') {
+            this.#checkProtocolNegotiationError(jsonResp);
+          }
         }
       }
       logApiError(`Error posting data to ${url}:`, error);

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -32,12 +32,12 @@ import {ProtocolNegotiationError} from '../../errorUtils.js';
 export class McpHttpTransportV20260618 extends McpHttpTransportBase {
   #getMeta() {
     return {
-      protocolVersion: this._protocolVersion,
-      clientInfo: {
+      'io.modelcontextprotocol/protocolVersion': this._protocolVersion,
+      'io.modelcontextprotocol/clientInfo': {
         name: this._clientName || 'toolbox-core-js',
         version: this._clientVersion || VERSION,
       },
-      clientCapabilities: {},
+      'io.modelcontextprotocol/clientCapabilities': {},
     };
   }
 

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -16,14 +16,91 @@ import {AxiosError} from 'axios';
 import {McpHttpTransportBase} from '../transportBase.js';
 import * as types from './types.js';
 
-import {ZodManifest} from '../../protocol.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../protocol.js';
 import {logApiError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
 import {v4 as uuidv4} from 'uuid';
 import {VERSION} from '../../version.js';
 
-export class McpHttpTransportV20251125 extends McpHttpTransportBase {
+import {ProtocolNegotiationError} from '../../errorUtils.js';
+
+export class McpHttpTransportV20260618 extends McpHttpTransportBase {
+  #getMeta() {
+    return {
+      protocolVersion: this._protocolVersion,
+      clientInfo: {
+        name: this._clientName || 'toolbox-core-js',
+        version: this._clientVersion || VERSION,
+      },
+      clientCapabilities: {},
+    };
+  }
+
+  #checkProtocolNegotiationError(errVal: unknown): void {
+    if (!errVal) return;
+
+    // Check for unsupported protocol version error code (-32022)
+    if (
+      typeof errVal === 'object' &&
+      errVal !== null &&
+      'code' in errVal &&
+      (errVal as Record<string, unknown>).code === -32022
+    ) {
+      const serverSupported = ((
+        (errVal as Record<string, unknown>).data as Record<string, unknown>
+      )?.supported || []) as string[];
+      const clientSupported = getSupportedMcpVersions();
+      const mutuallySupported = clientSupported.filter(v =>
+        serverSupported.includes(v),
+      );
+
+      if (mutuallySupported.length > 0) {
+        throw new ProtocolNegotiationError(mutuallySupported[0]);
+      } else {
+        throw new Error(
+          `No mutually supported protocol version. Client supports: ${clientSupported.join(
+            ', ',
+          )}, Server supports: ${serverSupported.join(', ')}`,
+        );
+      }
+    }
+
+    // Check for legacy fallback (string or object message matching)
+    const isLegacyError =
+      (typeof errVal === 'string' &&
+        (errVal.toLowerCase().includes('invalid protocol version') ||
+          errVal.toLowerCase().includes('unsupported protocol version'))) ||
+      (typeof errVal === 'object' &&
+        errVal !== null &&
+        'message' in errVal &&
+        (String((errVal as Record<string, unknown>).message)
+          .toLowerCase()
+          .includes('invalid protocol version') ||
+          String((errVal as Record<string, unknown>).message)
+            .toLowerCase()
+            .includes('unsupported protocol version')));
+
+    if (isLegacyError) {
+      // Cascading Fallback
+      const clientSupported = getSupportedMcpVersions();
+      const currentIdx = clientSupported.indexOf(
+        this._protocolVersion as Protocol,
+      );
+      if (currentIdx !== -1 && currentIdx + 1 < clientSupported.length) {
+        throw new ProtocolNegotiationError(clientSupported[currentIdx + 1]);
+      } else {
+        throw new Error(
+          "Server threw 'invalid protocol version' but no fallback versions remain in the user's supported protocols array.",
+        );
+      }
+    }
+  }
+
   async #sendRequest<T>(
     url: string,
     request: types.MCPRequest<T> | types.MCPNotification,
@@ -77,7 +154,10 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       const jsonResp = response.data;
 
-      if (jsonResp.error) {
+      if (jsonResp && typeof jsonResp === 'object' && jsonResp.error) {
+        const errVal = jsonResp.error;
+        this.#checkProtocolNegotiationError(errVal);
+
         const errResult = types.JSONRPCErrorSchema.safeParse(jsonResp);
         let message = `MCP request failed: ${JSON.stringify(jsonResp.error)}`;
         let code = 'MCP_ERROR';
@@ -109,60 +189,21 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
 
       return null;
     } catch (error) {
+      if (error instanceof AxiosError) {
+        const jsonResp = error.response?.data;
+        if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
+          const errVal = (jsonResp as Record<string, unknown>).error;
+          this.#checkProtocolNegotiationError(errVal);
+        }
+      }
       logApiError(`Error posting data to ${url}:`, error);
       throw error;
     }
   }
 
-  protected async initializeSession(
-    headers?: Record<string, string>,
-  ): Promise<void> {
-    const params: types.InitializeRequestParams = {
-      protocolVersion: this._protocolVersion,
-      capabilities: {},
-      clientInfo: {
-        name: this._clientName || 'toolbox-core-js',
-        version: this._clientVersion || VERSION,
-      },
-    };
-
-    const result = await this.#sendRequest(
-      this._mcpBaseUrl,
-      types.InitializeRequest,
-      params,
-      headers,
-    );
-
-    if (!result) {
-      const error = new Error('Initialization failed: No response');
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    this._serverVersion = result.serverInfo.version;
-
-    if (result.protocolVersion !== this._protocolVersion) {
-      const error = new Error(
-        `MCP version mismatch: client does not support server version ${result.protocolVersion}`,
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    if (!result.capabilities.tools) {
-      const error = new Error(
-        "Server does not support the 'tools' capability.",
-      );
-      logApiError('MCP Initialization Error', error);
-      throw error;
-    }
-
-    await this.#sendRequest(
-      this._mcpBaseUrl,
-      types.InitializedNotification,
-      {},
-      headers,
-    );
+  protected async initializeSession(): Promise<void> {
+    // Stateless MCP does not use initialize handshake
+    this._serverVersion = 'unknown';
   }
 
   async toolsList(
@@ -175,19 +216,13 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     const result = await this.#sendRequest(
       url,
       types.ListToolsRequest,
-      {},
+      {_meta: this.#getMeta()},
       headers,
     );
 
     if (!result) {
       const error = new Error('Failed to list tools: No response from server.');
       logApiError(`Error listing tools from ${url}`, error);
-      throw error;
-    }
-
-    if (this._serverVersion === null) {
-      const error = new Error('Server version not available.');
-      logApiError('Error listing tools', error);
       throw error;
     }
 
@@ -205,8 +240,8 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     }
 
     return {
-      serverVersion: this._serverVersion,
-      tools: toolsMap as unknown as ZodManifest['tools'], // Cast to verify structure compliance or rely on structural typing
+      serverVersion: this._serverVersion ?? 'unknown',
+      tools: toolsMap as unknown as ZodManifest['tools'],
     };
   }
 
@@ -236,13 +271,14 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
   ): Promise<string> {
     await this.ensureInitialized(headers);
 
-    if (Object.keys(headers).length > 0) {
+    if (headers && Object.keys(headers).length > 0) {
       warnIfHttpAndHeaders(this._mcpBaseUrl, headers);
     }
 
-    const params: types.CallToolRequestParams = {
+    const params = {
       name: toolName,
       arguments: arguments_,
+      _meta: this.#getMeta(),
     };
 
     const result = await this.#sendRequest(

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -44,12 +44,13 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
   #checkProtocolNegotiationError(errVal: unknown): void {
     if (!errVal) return;
 
-    // Check for unsupported protocol version error code (-32022)
+    // Check for unsupported protocol version error code (-32022 or -32004)
     if (
       typeof errVal === 'object' &&
       errVal !== null &&
       'code' in errVal &&
-      (errVal as Record<string, unknown>).code === -32022
+      ((errVal as Record<string, unknown>).code === -32022 ||
+        (errVal as Record<string, unknown>).code === -32004)
     ) {
       const serverSupported = ((
         (errVal as Record<string, unknown>).data as Record<string, unknown>
@@ -71,19 +72,16 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
     }
 
     // Check for legacy fallback (string or object message matching)
+    const errMsg =
+      typeof errVal === 'string'
+        ? errVal.toLowerCase()
+        : typeof errVal === 'object' && errVal !== null && 'message' in errVal
+          ? String((errVal as Record<string, unknown>).message).toLowerCase()
+          : '';
+
     const isLegacyError =
-      (typeof errVal === 'string' &&
-        (errVal.toLowerCase().includes('invalid protocol version') ||
-          errVal.toLowerCase().includes('unsupported protocol version'))) ||
-      (typeof errVal === 'object' &&
-        errVal !== null &&
-        'message' in errVal &&
-        (String((errVal as Record<string, unknown>).message)
-          .toLowerCase()
-          .includes('invalid protocol version') ||
-          String((errVal as Record<string, unknown>).message)
-            .toLowerCase()
-            .includes('unsupported protocol version')));
+      errMsg.includes('invalid protocol version') ||
+      errMsg.includes('unsupported protocol version');
 
     if (isLegacyError) {
       // Cascading Fallback
@@ -131,6 +129,23 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
     // Inject Protocol Version into headers as required by MCP spec
     const reqHeaders = {...(headers || {})};
     reqHeaders['MCP-Protocol-Version'] = this._protocolVersion;
+
+    // Inject SEP-2243 routing headers
+    reqHeaders['Mcp-Method'] = method;
+    if (typeof params === 'object' && params !== null) {
+      if (
+        (method === 'tools/call' || method === 'prompts/get') &&
+        'name' in params
+      ) {
+        reqHeaders['Mcp-Name'] = String(
+          (params as Record<string, unknown>).name,
+        );
+      } else if (method === 'resources/read' && 'uri' in params) {
+        reqHeaders['Mcp-Name'] = String(
+          (params as Record<string, unknown>).uri,
+        );
+      }
+    }
 
     try {
       const response = await this._session.post(url, payload, {
@@ -189,6 +204,9 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
 
       return null;
     } catch (error) {
+      if (error instanceof ProtocolNegotiationError) {
+        throw error;
+      }
       if (error instanceof AxiosError) {
         const jsonResp = error.response?.data;
         if (jsonResp && typeof jsonResp === 'object' && 'error' in jsonResp) {
@@ -275,7 +293,9 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
       warnIfHttpAndHeaders(this._mcpBaseUrl, headers);
     }
 
-    const params = {
+    const params: types.CallToolRequestParams & {
+      _meta?: Record<string, unknown>;
+    } = {
       name: toolName,
       arguments: arguments_,
       _meta: this.#getMeta(),

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/mcp.ts
@@ -219,8 +219,12 @@ export class McpHttpTransportV20260618 extends McpHttpTransportBase {
     }
   }
 
-  protected async initializeSession(): Promise<void> {
-    // Stateless MCP does not use initialize handshake
+  protected async initializeSession(
+    // Required to match McpHttpTransportBase signature, but unused because
+    // Stateless MCP does not use an initialize handshake.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _headers?: Record<string, string>,
+  ): Promise<void> {
     this._serverVersion = 'unknown';
   }
 

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260618/types.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260618/types.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+
+export const RequestParamsSchema = z.object({}).passthrough();
+export type RequestParams = z.infer<typeof RequestParamsSchema>;
+
+export const JSONRPCRequestSchema = z.object({
+  jsonrpc: z.literal('2.0').default('2.0'),
+  id: z.union([z.string(), z.number()]).optional(), // Default handled in usage, or logic
+  method: z.string(),
+  params: z.record(z.unknown()).optional().nullable(),
+});
+export type JSONRPCRequest = z.infer<typeof JSONRPCRequestSchema>;
+
+export const JSONRPCNotificationSchema = z.object({
+  jsonrpc: z.literal('2.0').default('2.0'),
+  method: z.string(),
+  params: z.record(z.unknown()).optional().nullable(),
+});
+export type JSONRPCNotification = z.infer<typeof JSONRPCNotificationSchema>;
+
+export const JSONRPCResponseSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]),
+  result: z.record(z.unknown()),
+});
+export type JSONRPCResponse = z.infer<typeof JSONRPCResponseSchema>;
+
+export const ErrorDataSchema = z.object({
+  code: z.number().int(),
+  message: z.string(),
+  data: z.unknown().optional().nullable(),
+});
+export type ErrorData = z.infer<typeof ErrorDataSchema>;
+
+export const JSONRPCErrorSchema = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.union([z.string(), z.number()]),
+  error: ErrorDataSchema,
+});
+export type JSONRPCError = z.infer<typeof JSONRPCErrorSchema>;
+
+export const BaseMetadataSchema = z
+  .object({
+    name: z.string(),
+  })
+  .passthrough();
+export type BaseMetadata = z.infer<typeof BaseMetadataSchema>;
+
+export const ToolSchema = BaseMetadataSchema.extend({
+  description: z.string().optional().nullable(),
+  inputSchema: z.record(z.unknown()),
+});
+
+export type Tool = z.infer<typeof ToolSchema>;
+
+export const ListToolsResultSchema = z.object({
+  tools: z.array(ToolSchema),
+});
+export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
+
+export const TextContentSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+export type TextContent = z.infer<typeof TextContentSchema>;
+
+export const CallToolResultSchema = z.object({
+  content: z.array(TextContentSchema),
+  isError: z.boolean().default(false).optional(),
+});
+export type CallToolResult = z.infer<typeof CallToolResultSchema>;
+
+// Generic Request/Notification types for internal usage (not full schemas)
+export type MCPRequest<T> = {
+  method: string;
+  params?: Record<string, unknown> | unknown | null;
+  getResultModel: () => z.ZodType<T>;
+};
+
+export type MCPNotification = {
+  method: string;
+  params?: Record<string, unknown> | unknown | null;
+};
+
+// Request/Notification Classes/Factories
+
+export const ListToolsRequest: MCPRequest<ListToolsResult> = {
+  method: 'tools/list',
+  params: {},
+  getResultModel: () => ListToolsResultSchema,
+};
+
+export const CallToolRequestParamsSchema = z.object({
+  name: z.string(),
+  arguments: z.record(z.unknown()),
+});
+export type CallToolRequestParams = z.infer<typeof CallToolRequestParamsSchema>;
+
+export const CallToolRequest: MCPRequest<CallToolResult> = {
+  method: 'tools/call',
+  // params computed at runtime
+  getResultModel: () => CallToolResultSchema,
+};

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -20,14 +20,15 @@ export enum Protocol {
   MCP_v20250326 = '2025-03-26',
   MCP_v20250618 = '2025-06-18',
   MCP_v20251125 = '2025-11-25',
-  MCP = MCP_v20250618, // Default MCP
-  MCP_LATEST = MCP_DRAFT_2026_v1,
+  MCP = MCP_v20251125,
+  MCP_LATEST = MCP_v20251125,
+  MCP_DRAFT = MCP_DRAFT_2026_v1,
 }
 
 export const MCP_LATEST = Protocol.MCP_LATEST;
 export function getSupportedMcpVersions(): Protocol[] {
   return [
-    Protocol.MCP_DRAFT_2026_v1,
+    Protocol.MCP_DRAFT,
     Protocol.MCP_v20251125,
     Protocol.MCP_v20250618,
     Protocol.MCP_v20250326,

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -15,6 +15,7 @@
 import {z, ZodRawShape, ZodTypeAny, ZodObject} from 'zod';
 
 export enum Protocol {
+  MCP_DRAFT_2026_v1 = 'DRAFT-2026-v1',
   MCP_v20241105 = '2024-11-05',
   MCP_v20250326 = '2025-03-26',
   MCP_v20250618 = '2025-06-18',
@@ -22,14 +23,15 @@ export enum Protocol {
   MCP = MCP_v20250618, // Default MCP
 }
 
-export const MCP_LATEST = Protocol.MCP_v20251125;
+export const MCP_LATEST = Protocol.MCP_DRAFT_2026_v1;
 
 export function getSupportedMcpVersions(): Protocol[] {
   return [
-    Protocol.MCP_v20241105,
-    Protocol.MCP_v20250326,
-    Protocol.MCP_v20250618,
+    Protocol.MCP_DRAFT_2026_v1,
     Protocol.MCP_v20251125,
+    Protocol.MCP_v20250618,
+    Protocol.MCP_v20250326,
+    Protocol.MCP_v20241105,
   ];
 }
 

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -21,10 +21,10 @@ export enum Protocol {
   MCP_v20250618 = '2025-06-18',
   MCP_v20251125 = '2025-11-25',
   MCP = MCP_v20250618, // Default MCP
+  MCP_LATEST = MCP_DRAFT_2026_v1,
 }
 
-export const MCP_LATEST = Protocol.MCP_v20251125;
-
+export const MCP_LATEST = Protocol.MCP_LATEST;
 export function getSupportedMcpVersions(): Protocol[] {
   return [
     Protocol.MCP_DRAFT_2026_v1,

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -23,7 +23,7 @@ export enum Protocol {
   MCP = MCP_v20250618, // Default MCP
 }
 
-export const MCP_LATEST = Protocol.MCP_DRAFT_2026_v1;
+export const MCP_LATEST = Protocol.MCP_v20251125;
 
 export function getSupportedMcpVersions(): Protocol[] {
   return [

--- a/packages/toolbox-core/src/toolbox_core/transport.types.ts
+++ b/packages/toolbox-core/src/toolbox_core/transport.types.ts
@@ -27,6 +27,11 @@ export interface ITransport {
   readonly protocolVersion: string;
 
   /**
+   * The list of supported protocols that the client claims to support.
+   */
+  supportedProtocols?: string[];
+
+  /**
    * The base URL for the transport.
    */
   readonly baseUrl: string;

--- a/packages/toolbox-core/src/toolbox_core/transport.types.ts
+++ b/packages/toolbox-core/src/toolbox_core/transport.types.ts
@@ -22,6 +22,11 @@ import {ZodManifest} from './protocol.js';
  */
 export interface ITransport {
   /**
+   * The negotiated protocol version of the transport.
+   */
+  readonly protocolVersion: string;
+
+  /**
    * The base URL for the transport.
    */
   readonly baseUrl: string;

--- a/packages/toolbox-core/test/e2e/jest.globalSetup.ts
+++ b/packages/toolbox-core/test/e2e/jest.globalSetup.ts
@@ -51,102 +51,134 @@ export default async function globalSetup(): Promise<void> {
     const toolboxGcsPath = getToolboxBinaryGcsPath(toolboxVersion);
     const localToolboxPath = path.resolve(__dirname, TOOLBOX_BINARY_NAME);
 
+    const bucketName = 'mcp-toolbox-for-databases';
     console.log(
-      `Downloading toolbox binary from gs://mcp-toolbox-for-databases/${toolboxGcsPath} to ${localToolboxPath}...`,
+      `Downloading toolbox binary from gs://${bucketName}/${toolboxGcsPath} to ${localToolboxPath}...`,
     );
-    await downloadBlob(
-      'mcp-toolbox-for-databases',
-      toolboxGcsPath,
-      localToolboxPath,
-    );
+    await downloadBlob(bucketName, toolboxGcsPath, localToolboxPath);
     console.log('Toolbox binary downloaded successfully.');
 
     // Make toolbox executable
     await fs.chmod(localToolboxPath, 0o700);
 
-    // Start toolbox server
-    console.log('Starting toolbox server process...');
-    const serverProcess = spawn(
+    // Start toolbox servers
+    console.log('Starting toolbox server processes...');
+    const serverProcess1 = spawn(
       localToolboxPath,
-      ['--tools-file', toolsFilePath],
+      ['--port', '5000', '--tools-file', toolsFilePath],
       {
-        stdio: ['ignore', 'pipe', 'pipe'], // ignore stdin, pipe stdout/stderr
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    const serverProcess2 = spawn(
+      localToolboxPath,
+      ['--port', '5001', '--tools-file', toolsFilePath, '--enable-draft-specs'],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
       },
     );
 
-    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ = serverProcess;
+    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ = serverProcess1;
+    (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS_2__ = serverProcess2;
 
-    serverProcess.stdout?.on('data', (data: Buffer) => {
-      console.log(`[ToolboxServer STDOUT]: ${data.toString().trim()}`);
+    serverProcess1.stdout?.on('data', (data: Buffer) => {
+      console.log(`[ToolboxServer1 STDOUT]: ${data.toString().trim()}`);
     });
-
-    serverProcess.stderr?.on('data', (data: Buffer) => {
-      console.error(`[ToolboxServer STDERR]: ${data.toString().trim()}`);
+    serverProcess1.stderr?.on('data', (data: Buffer) => {
+      console.error(`[ToolboxServer1 STDERR]: ${data.toString().trim()}`);
     });
-
-    serverProcess.on('error', err => {
-      console.error('Toolbox server process error:', err);
-      throw new Error('Failed to start toolbox server process.');
+    serverProcess1.on('error', err => {
+      console.error('Toolbox server 1 process error:', err);
+      throw new Error('Failed to start toolbox server 1 process.');
     });
-
-    serverProcess.on('exit', (code, signal) => {
+    serverProcess1.on('exit', (code, signal) => {
       console.log(
-        `Toolbox server process exited with code ${code}, signal ${signal}.`,
+        `Toolbox server 1 process exited with code ${code}, signal ${signal}.`,
       );
       if (
         (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS__ &&
         !(globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__
       ) {
-        console.error('Toolbox server exited prematurely during setup.');
+        console.error('Toolbox server 1 exited prematurely during setup.');
       }
     });
 
-    // Wait for server to start (basic poll check)
-    let started = false;
+    serverProcess2.stdout?.on('data', (data: Buffer) => {
+      console.log(`[ToolboxServer2 STDOUT]: ${data.toString().trim()}`);
+    });
+    serverProcess2.stderr?.on('data', (data: Buffer) => {
+      console.error(`[ToolboxServer2 STDERR]: ${data.toString().trim()}`);
+    });
+    serverProcess2.on('error', err => {
+      console.error('Toolbox server 2 process error:', err);
+      throw new Error('Failed to start toolbox server 2 process.');
+    });
+    serverProcess2.on('exit', (code, signal) => {
+      console.log(
+        `Toolbox server 2 process exited with code ${code}, signal ${signal}.`,
+      );
+      if (
+        (globalThis as CustomGlobal).__TOOLBOX_SERVER_PROCESS_2__ &&
+        !(globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__
+      ) {
+        console.error('Toolbox server 2 exited prematurely during setup.');
+      }
+    });
+
+    // Wait for servers to start (basic poll check)
+    let started1 = false;
+    let started2 = false;
     const startTime = Date.now();
     while (Date.now() - startTime < SERVER_READY_TIMEOUT_MS) {
       if (
-        serverProcess.pid &&
-        !serverProcess.killed &&
-        serverProcess.exitCode === null
+        serverProcess1.pid &&
+        !serverProcess1.killed &&
+        serverProcess1.exitCode === null
       ) {
+        started1 = true;
+      }
+      if (
+        serverProcess2.pid &&
+        !serverProcess2.killed &&
+        serverProcess2.exitCode === null
+      ) {
+        started2 = true;
+      }
+      if (started1 && started2) {
         console.log(
-          'Toolbox server process appears to be running. Polling for stability...',
+          'Both Toolbox servers started successfully (processes are active).',
         );
-        await delay(SERVER_READY_POLL_INTERVAL_MS * 2);
-        if (serverProcess.exitCode === null) {
-          console.log(
-            'Toolbox server started successfully (process is active).',
-          );
-          started = true;
-          break;
-        } else {
-          console.log('Toolbox server process exited after initial start.');
-          break;
-        }
+        break;
       }
       await delay(SERVER_READY_POLL_INTERVAL_MS);
-      console.log('Checking if toolbox server is started...');
+      console.log('Checking if toolbox servers are started...');
     }
 
-    if (!started) {
-      if (serverProcess && !serverProcess.killed) {
-        serverProcess.kill('SIGTERM');
-      }
+    if (!started1 || !started2) {
+      if (serverProcess1 && !serverProcess1.killed)
+        serverProcess1.kill('SIGTERM');
+      if (serverProcess2 && !serverProcess2.killed)
+        serverProcess2.kill('SIGTERM');
       throw new Error(
-        `Toolbox server failed to start within ${SERVER_READY_TIMEOUT_MS / 1000} seconds.`,
+        `Toolbox servers failed to start within ${SERVER_READY_TIMEOUT_MS / 1000} seconds.`,
       );
     }
 
     console.log('Jest Global Setup: Completed successfully.');
   } catch (error) {
     console.error('Jest Global Setup Failed:', error);
-    // Attempt to kill server if it started partially
-    const serverProcess = (globalThis as CustomGlobal)
+    // Attempt to kill servers if they started partially
+    const serverProcess1 = (globalThis as CustomGlobal)
       .__TOOLBOX_SERVER_PROCESS__;
-    if (serverProcess && !serverProcess.killed) {
-      console.log('Attempting to terminate partially started server...');
-      serverProcess.kill('SIGKILL');
+    const serverProcess2 = (globalThis as CustomGlobal)
+      .__TOOLBOX_SERVER_PROCESS_2__;
+    if (serverProcess1 && !serverProcess1.killed) {
+      console.log('Attempting to terminate partially started server 1...');
+      serverProcess1.kill('SIGKILL');
+    }
+    if (serverProcess2 && !serverProcess2.killed) {
+      console.log('Attempting to terminate partially started server 2...');
+      serverProcess2.kill('SIGKILL');
     }
     // Clean up temp file if created
     const toolsFilePath = (globalThis as CustomGlobal).__TOOLS_FILE_PATH__;

--- a/packages/toolbox-core/test/e2e/jest.globalTeardown.ts
+++ b/packages/toolbox-core/test/e2e/jest.globalTeardown.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as fs from 'fs-extra';
+import {ChildProcess} from 'child_process';
 import {CustomGlobal} from './types';
 
 const SERVER_TERMINATE_TIMEOUT_MS = 10000; // 10 seconds
@@ -22,50 +23,67 @@ export default async function globalTeardown(): Promise<void> {
   (globalThis as CustomGlobal).__SERVER_TEARDOWN_INITIATED__ = true;
 
   const customGlobal = globalThis as CustomGlobal;
-  const serverProcess = customGlobal.__TOOLBOX_SERVER_PROCESS__;
+  const serverProcess1 = customGlobal.__TOOLBOX_SERVER_PROCESS__;
+  const serverProcess2 = customGlobal.__TOOLBOX_SERVER_PROCESS_2__;
   const toolsFilePath = customGlobal.__TOOLS_FILE_PATH__;
 
-  if (serverProcess && !serverProcess.killed) {
-    console.log('Stopping toolbox server process...');
-    serverProcess.kill('SIGTERM'); // Graceful termination
+  const killServer = async (
+    serverProcess: ChildProcess | undefined,
+    name: string,
+  ) => {
+    if (serverProcess && !serverProcess.killed) {
+      console.log(`Stopping toolbox server ${name} process...`);
+      serverProcess.kill('SIGTERM'); // Graceful termination
 
-    // Wait for the process to exit
-    const stopPromise = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        if (!serverProcess.killed) {
-          console.warn(
-            'Toolbox server did not terminate gracefully, sending SIGKILL.',
-          );
-          serverProcess.kill('SIGKILL');
-        }
-        // Resolve even if SIGKILL is needed, as we want teardown to finish
-        resolve();
-      }, SERVER_TERMINATE_TIMEOUT_MS);
+      // Wait for the process to exit
+      const stopPromise = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          if (!serverProcess.killed) {
+            console.warn(
+              `Toolbox server ${name} did not terminate gracefully, sending SIGKILL.`,
+            );
+            serverProcess.kill('SIGKILL');
+          }
+          // Resolve even if SIGKILL is needed, as we want teardown to finish
+          resolve();
+        }, SERVER_TERMINATE_TIMEOUT_MS);
 
-      serverProcess.on('exit', (code, signal) => {
-        clearTimeout(timeout);
-        console.log(
-          `Toolbox server process exited with code ${code}, signal ${signal} during teardown.`,
+        serverProcess.on(
+          'exit',
+          (code: number | null, signal: NodeJS.Signals | null) => {
+            clearTimeout(timeout);
+            console.log(
+              `Toolbox server ${name} process exited with code ${code}, signal ${signal} during teardown.`,
+            );
+            resolve();
+          },
         );
-        resolve();
+        serverProcess.on('error', (err: Error) => {
+          // Should not happen if already running
+          clearTimeout(timeout);
+          console.error(
+            `Error during server ${name} process termination:`,
+            err,
+          );
+          reject(err);
+        });
       });
-      serverProcess.on('error', err => {
-        // Should not happen if already running
-        clearTimeout(timeout);
-        console.error('Error during server process termination:', err);
-        reject(err);
-      });
-    });
 
-    try {
-      await stopPromise;
-    } catch (error) {
-      console.error('Error while waiting for server to stop:', error);
-      if (!serverProcess.killed) serverProcess.kill('SIGKILL'); // Ensure it's killed
+      try {
+        await stopPromise;
+      } catch (error) {
+        console.error(`Error while waiting for server ${name} to stop:`, error);
+        if (!serverProcess.killed) serverProcess.kill('SIGKILL'); // Ensure it's killed
+      }
+    } else {
+      console.log(
+        `Toolbox server ${name} process was not running or already handled.`,
+      );
     }
-  } else {
-    console.log('Toolbox server process was not running or already handled.');
-  }
+  };
+
+  await killServer(serverProcess1, '1');
+  await killServer(serverProcess2, '2');
 
   if (toolsFilePath) {
     try {
@@ -79,6 +97,7 @@ export default async function globalTeardown(): Promise<void> {
     }
   }
   customGlobal.__TOOLBOX_SERVER_PROCESS__ = undefined;
+  customGlobal.__TOOLBOX_SERVER_PROCESS_2__ = undefined;
   customGlobal.__TOOLS_FILE_PATH__ = undefined;
   customGlobal.__GOOGLE_CLOUD_PROJECT__ = undefined;
 

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -14,7 +14,10 @@
 
 import {ToolboxClient} from '../../src/toolbox_core/client.js';
 import {ToolboxTool} from '../../src/toolbox_core/tool.js';
-import {getSupportedMcpVersions} from '../../src/toolbox_core/protocol.js';
+import {
+  Protocol,
+  getSupportedMcpVersions,
+} from '../../src/toolbox_core/protocol.js';
 
 import {AxiosError} from 'axios';
 import {CustomGlobal} from './types.js';
@@ -618,3 +621,18 @@ describe.each(getSupportedMcpVersions())(
     });
   },
 );
+
+describe('ToolboxClient E2E Protocol Negotiation Fallback', () => {
+  it('should successfully fallback to a supported version when draft specs are disabled on the server', async () => {
+    const testBaseUrl = 'http://localhost:5000';
+    const client = new ToolboxClient(
+      testBaseUrl,
+      undefined,
+      undefined,
+      Protocol.MCP_DRAFT_2026_v1,
+    );
+
+    const tool = await client.loadTool('get-n-rows');
+    expect(tool.getName()).toBe('get-n-rows');
+  });
+});

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -25,9 +25,9 @@ import {CustomGlobal} from './types.js';
 import {authTokenGetter} from './utils.js';
 import {ZodTypeAny} from 'zod';
 
-const LEGACY_SERVER_URL = 'http://localhost:5000';
-const DRAFT_SERVER_URL = 'http://localhost:5001';
-const testBaseUrls = [LEGACY_SERVER_URL, DRAFT_SERVER_URL];
+const TOOLBOX_SERVER_URL_STABLE = 'http://localhost:5000';
+const TOOLBOX_SERVER_URL_DRAFT = 'http://localhost:5001';
+const testBaseUrls = [TOOLBOX_SERVER_URL_STABLE, TOOLBOX_SERVER_URL_DRAFT];
 
 testBaseUrls.forEach(testBaseUrl => {
   describe.each(getSupportedMcpVersions())(
@@ -651,7 +651,7 @@ testBaseUrls.forEach(testBaseUrl => {
       expect(response).toContain('row1');
     });
 
-    if (testBaseUrl === LEGACY_SERVER_URL) {
+    if (testBaseUrl === TOOLBOX_SERVER_URL_STABLE) {
       it('should fallback to an older protocol against a server that does not support the draft version', async () => {
         const session = axios.create();
         const postSpy = jest.spyOn(session, 'post');
@@ -672,7 +672,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 1: Draft tools/list (fails)
         const call1 = postSpy.mock.calls[0];
-        expect(call1[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
@@ -680,7 +680,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 2: Stateful Initialize (succeeds)
         const call2 = postSpy.mock.calls[1];
-        expect(call2[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call2[1] as Record<string, unknown>).method).toBe('initialize');
         expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
@@ -688,7 +688,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 3: Stateful Initialized Notification (succeeds)
         const call3 = postSpy.mock.calls[2];
-        expect(call3[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call3[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call3[1] as Record<string, unknown>).method).toBe(
           'notifications/initialized',
         );
@@ -698,7 +698,7 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 4: Stateful tools/list (succeeds)
         const call4 = postSpy.mock.calls[3];
-        expect(call4[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call4[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call4[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call4[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
@@ -706,13 +706,13 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 5: Stateful tools/call (succeeds)
         const call5 = postSpy.mock.calls[4];
-        expect(call5[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect(call5[0]).toBe(`${TOOLBOX_SERVER_URL_STABLE}/mcp/`);
         expect((call5[1] as Record<string, unknown>).method).toBe('tools/call');
         expect(call5[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_v20251125,
         );
       });
-    } else if (testBaseUrl === DRAFT_SERVER_URL) {
+    } else if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
       it('should successfully connect using the draft version without fallback', async () => {
         const session = axios.create();
         const postSpy = jest.spyOn(session, 'post');
@@ -728,12 +728,13 @@ testBaseUrls.forEach(testBaseUrl => {
         const response = await tool({num_rows: '1'});
         expect(typeof response).toBe('string');
         expect(response).toContain('row1');
+        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT_2026_v1);
 
         expect(postSpy).toHaveBeenCalledTimes(2);
 
         // Call 1: Draft tools/list (succeeds)
         const call1 = postSpy.mock.calls[0];
-        expect(call1[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
         expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
         expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
@@ -741,12 +742,48 @@ testBaseUrls.forEach(testBaseUrl => {
 
         // Call 2: Draft tools/call (succeeds)
         const call2 = postSpy.mock.calls[1];
-        expect(call2[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
         expect((call2[1] as Record<string, unknown>).method).toBe('tools/call');
         expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
           Protocol.MCP_DRAFT_2026_v1,
         );
       });
     }
+
+    it('should correctly negotiate Protocol.MCP_LATEST', async () => {
+      const client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_LATEST,
+      );
+
+      const tool = await client.loadTool('get-n-rows');
+      const response = await tool({num_rows: '1'});
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
+
+      expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+    });
+
+    it('should correctly negotiate with a custom list [Protocol.MCP_v20241105, Protocol.MCP_v20250326, Protocol.MCP_LATEST, Protocol.MCP_DRAFT]', async () => {
+      const client = new ToolboxClient(testBaseUrl, undefined, undefined, [
+        Protocol.MCP_v20241105,
+        Protocol.MCP_v20250326,
+        Protocol.MCP_LATEST,
+        Protocol.MCP_DRAFT,
+      ]);
+
+      const tool = await client.loadTool('get-n-rows');
+      const response = await tool({num_rows: '1'});
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
+
+      if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT);
+      } else {
+        expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+      }
+    });
   });
 });

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -19,82 +19,124 @@ import {
   getSupportedMcpVersions,
 } from '../../src/toolbox_core/protocol.js';
 
-import {AxiosError} from 'axios';
+import {jest} from '@jest/globals';
+import axios, {AxiosError} from 'axios';
 import {CustomGlobal} from './types.js';
 import {authTokenGetter} from './utils.js';
 import {ZodTypeAny} from 'zod';
 
-describe.each(getSupportedMcpVersions())(
-  'ToolboxClient E2E MCP Tests (%s)',
-  protocolVersion => {
-    let commonToolboxClient: ToolboxClient;
-    let getNRowsTool: ReturnType<typeof ToolboxTool>;
-    const testBaseUrl = 'http://localhost:5000';
-    const projectId = (globalThis as CustomGlobal).__GOOGLE_CLOUD_PROJECT__;
+const LEGACY_SERVER_URL = 'http://localhost:5000';
+const DRAFT_SERVER_URL = 'http://localhost:5001';
+const testBaseUrls = [LEGACY_SERVER_URL, DRAFT_SERVER_URL];
 
-    beforeAll(async () => {
-      commonToolboxClient = new ToolboxClient(
-        testBaseUrl,
-        undefined,
-        undefined,
-        protocolVersion,
-      );
-    });
+testBaseUrls.forEach(testBaseUrl => {
+  describe.each(getSupportedMcpVersions())(
+    `ToolboxClient E2E MCP Tests against ${testBaseUrl} (%s)`,
+    protocolVersion => {
+      let commonToolboxClient: ToolboxClient;
+      let getNRowsTool: ReturnType<typeof ToolboxTool>;
+      const projectId = (globalThis as CustomGlobal).__GOOGLE_CLOUD_PROJECT__;
 
-    beforeEach(async () => {
-      getNRowsTool = await commonToolboxClient.loadTool('get-n-rows');
-      expect(getNRowsTool.getName()).toBe('get-n-rows');
-    });
-
-    describe('invokeTool', () => {
-      it('should invoke the getNRowsTool', async () => {
-        const response = await getNRowsTool({num_rows: '2'});
-        expect(typeof response).toBe('string');
-        expect(response).toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).not.toContain('row3');
-      });
-
-      it('should invoke the getNRowsTool with missing params', async () => {
-        await expect(getNRowsTool()).rejects.toThrow(
-          /Argument validation failed for tool "get-n-rows":\s*- num_rows: Required/,
+      beforeAll(async () => {
+        commonToolboxClient = new ToolboxClient(
+          testBaseUrl,
+          undefined,
+          undefined,
+          protocolVersion,
         );
       });
 
-      it('should invoke the getNRowsTool with wrong param type', async () => {
-        await expect(getNRowsTool({num_rows: 2})).rejects.toThrow(
-          /Argument validation failed for tool "get-n-rows":\s*- num_rows: Expected string, received number/,
-        );
+      beforeEach(async () => {
+        getNRowsTool = await commonToolboxClient.loadTool('get-n-rows');
+        expect(getNRowsTool.getName()).toBe('get-n-rows');
       });
-    });
 
-    describe('loadToolset', () => {
-      const specificToolsetTestCases = [
-        {
-          name: 'my-toolset',
-          expectedLength: 1,
-          expectedTools: ['get-row-by-id'],
-        },
-        {
-          name: 'my-toolset-2',
-          expectedLength: 2,
-          expectedTools: ['get-n-rows', 'get-row-by-id'],
-        },
-      ];
+      describe('invokeTool', () => {
+        it('should invoke the getNRowsTool', async () => {
+          const response = await getNRowsTool({num_rows: '2'});
+          expect(typeof response).toBe('string');
+          expect(response).toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).not.toContain('row3');
+        });
 
-      specificToolsetTestCases.forEach(testCase => {
-        it(`should successfully load the specific toolset "${testCase.name}"`, async () => {
-          const loadedTools = await commonToolboxClient.loadToolset(
-            testCase.name,
+        it('should invoke the getNRowsTool with missing params', async () => {
+          await expect(getNRowsTool()).rejects.toThrow(
+            /Argument validation failed for tool "get-n-rows":\s*- num_rows: Required/,
+          );
+        });
+
+        it('should invoke the getNRowsTool with wrong param type', async () => {
+          await expect(getNRowsTool({num_rows: 2})).rejects.toThrow(
+            /Argument validation failed for tool "get-n-rows":\s*- num_rows: Expected string, received number/,
+          );
+        });
+      });
+
+      describe('loadToolset', () => {
+        const specificToolsetTestCases = [
+          {
+            name: 'my-toolset',
+            expectedLength: 1,
+            expectedTools: ['get-row-by-id'],
+          },
+          {
+            name: 'my-toolset-2',
+            expectedLength: 2,
+            expectedTools: ['get-n-rows', 'get-row-by-id'],
+          },
+        ];
+
+        specificToolsetTestCases.forEach(testCase => {
+          it(`should successfully load the specific toolset "${testCase.name}"`, async () => {
+            const loadedTools = await commonToolboxClient.loadToolset(
+              testCase.name,
+            );
+
+            expect(Array.isArray(loadedTools)).toBe(true);
+            expect(loadedTools.length).toBe(testCase.expectedLength);
+
+            const loadedToolNames = new Set(
+              loadedTools.map(tool => tool.getName()),
+            );
+            expect(loadedToolNames).toEqual(new Set(testCase.expectedTools));
+
+            for (const tool of loadedTools) {
+              expect(typeof tool).toBe('function');
+              expect(tool.getName).toBeInstanceOf(Function);
+              expect(tool.getDescription).toBeInstanceOf(Function);
+              expect(tool.getParamSchema).toBeInstanceOf(Function);
+            }
+          });
+        });
+
+        it('should successfully load the default toolset (all tools)', async () => {
+          const loadedTools = await commonToolboxClient.loadToolset(); // Load the default toolset (no name provided)
+          expect(Array.isArray(loadedTools)).toBe(true);
+          expect(loadedTools.length).toBeGreaterThan(0);
+          const getNRowsToolFromSet = loadedTools.find(
+            tool => tool.getName() === 'get-n-rows',
           );
 
-          expect(Array.isArray(loadedTools)).toBe(true);
-          expect(loadedTools.length).toBe(testCase.expectedLength);
+          expect(getNRowsToolFromSet).toBeDefined();
+          expect(typeof getNRowsToolFromSet).toBe('function');
+          expect(getNRowsToolFromSet?.getName()).toBe('get-n-rows');
+          expect(getNRowsToolFromSet?.getDescription()).toBeDefined();
+          expect(getNRowsToolFromSet?.getParamSchema()).toBeDefined();
 
           const loadedToolNames = new Set(
             loadedTools.map(tool => tool.getName()),
           );
-          expect(loadedToolNames).toEqual(new Set(testCase.expectedTools));
+          const expectedDefaultTools = new Set([
+            'get-row-by-content-auth',
+            'get-row-by-email-auth',
+            'get-row-by-id-auth',
+            'get-row-by-id',
+            'get-n-rows',
+            'search-rows',
+            'process-data',
+          ]);
+          expect(loadedToolNames).toEqual(expectedDefaultTools);
 
           for (const tool of loadedTools) {
             expect(typeof tool).toBe('function');
@@ -103,536 +145,608 @@ describe.each(getSupportedMcpVersions())(
             expect(tool.getParamSchema).toBeInstanceOf(Function);
           }
         });
-      });
 
-      it('should successfully load the default toolset (all tools)', async () => {
-        const loadedTools = await commonToolboxClient.loadToolset(); // Load the default toolset (no name provided)
-        expect(Array.isArray(loadedTools)).toBe(true);
-        expect(loadedTools.length).toBeGreaterThan(0);
-        const getNRowsToolFromSet = loadedTools.find(
-          tool => tool.getName() === 'get-n-rows',
-        );
-
-        expect(getNRowsToolFromSet).toBeDefined();
-        expect(typeof getNRowsToolFromSet).toBe('function');
-        expect(getNRowsToolFromSet?.getName()).toBe('get-n-rows');
-        expect(getNRowsToolFromSet?.getDescription()).toBeDefined();
-        expect(getNRowsToolFromSet?.getParamSchema()).toBeDefined();
-
-        const loadedToolNames = new Set(
-          loadedTools.map(tool => tool.getName()),
-        );
-        const expectedDefaultTools = new Set([
-          'get-row-by-content-auth',
-          'get-row-by-email-auth',
-          'get-row-by-id-auth',
-          'get-row-by-id',
-          'get-n-rows',
-          'search-rows',
-          'process-data',
-        ]);
-        expect(loadedToolNames).toEqual(expectedDefaultTools);
-
-        for (const tool of loadedTools) {
-          expect(typeof tool).toBe('function');
-          expect(tool.getName).toBeInstanceOf(Function);
-          expect(tool.getDescription).toBeInstanceOf(Function);
-          expect(tool.getParamSchema).toBeInstanceOf(Function);
-        }
-      });
-
-      it('should throw an error when trying to load a non-existent toolset', async () => {
-        await expect(
-          commonToolboxClient.loadToolset('non-existent-toolset'),
-        ).rejects.toThrow(
-          /MCP request failed with code -32600: toolset does not exist/,
-        );
-      });
-    });
-    describe('bindParams', () => {
-      it('should throw an error when attempting to provide user arguments for bound params', async () => {
-        const newTool = getNRowsTool.bindParam('num_rows', '3');
-        await expect(newTool({num_rows: '4'})).rejects.toThrow(
-          "unexpected parameter 'num_rows' provided",
-        );
-      });
-
-      it('should successfully bind a parameter with bindParam and invoke', async () => {
-        const newTool = getNRowsTool.bindParam('num_rows', '3');
-        const response = await newTool(); // Invoke with no args
-        expect(response).toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).toContain('row3');
-        expect(response).not.toContain('row4');
-      });
-
-      it('should successfully bind parameters with bindParams and invoke', async () => {
-        const newTool = getNRowsTool.bindParams({num_rows: '3'});
-        const response = await newTool(); // Invoke with no args
-        expect(response).toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).toContain('row3');
-        expect(response).not.toContain('row4');
-      });
-
-      it('should successfully bind a synchronous function value', async () => {
-        const newTool = getNRowsTool.bindParams({num_rows: () => '1'});
-        const response = await newTool();
-        expect(response).toContain('row1');
-        expect(response).not.toContain('row2');
-      });
-
-      it('should successfully bind an asynchronous function value', async () => {
-        const asyncNumProvider = async () => {
-          await new Promise(resolve => setTimeout(resolve, 10));
-          return '1';
-        };
-
-        const newTool = getNRowsTool.bindParams({num_rows: asyncNumProvider});
-        const response = await newTool();
-        expect(response).toContain('row1');
-        expect(response).not.toContain('row2');
-      });
-
-      it('should successfully bind parameters at load time', async () => {
-        const tool = await commonToolboxClient.loadTool('get-n-rows', null, {
-          num_rows: '3',
-        });
-        const response = await tool();
-        expect(response).toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).toContain('row3');
-        expect(response).not.toContain('row4');
-      });
-
-      it('should throw an error when re-binding an existing parameter', () => {
-        const newTool = getNRowsTool.bindParam('num_rows', '1');
-        expect(() => {
-          newTool.bindParam('num_rows', '2');
-        }).toThrow(
-          "Cannot re-bind parameter: parameter 'num_rows' is already bound in tool 'get-n-rows'.",
-        );
-      });
-
-      it('should throw an error when binding a non-existent parameter', () => {
-        expect(() => {
-          getNRowsTool.bindParam('non_existent_param', '2');
-        }).toThrow(
-          "Unable to bind parameter: no parameter named 'non_existent_param' in tool 'get-n-rows'.",
-        );
-      });
-    });
-
-    describe('Auth E2E Tests', () => {
-      let authToken1: string;
-      let authToken2: string;
-      let authToken1Getter: () => string;
-      let authToken2Getter: () => string;
-
-      beforeAll(async () => {
-        if (!projectId) {
-          throw new Error(
-            'GOOGLE_CLOUD_PROJECT is not defined. Cannot run Auth E2E tests.',
+        it('should throw an error when trying to load a non-existent toolset', async () => {
+          await expect(
+            commonToolboxClient.loadToolset('non-existent-toolset'),
+          ).rejects.toThrow(
+            /MCP request failed with code -32600: toolset does not exist/,
           );
-        }
-        authToken1 = await authTokenGetter(projectId, 'sdk_testing_client1');
-        authToken2 = await authTokenGetter(projectId, 'sdk_testing_client2');
+        });
+      });
+      describe('bindParams', () => {
+        it('should throw an error when attempting to provide user arguments for bound params', async () => {
+          const newTool = getNRowsTool.bindParam('num_rows', '3');
+          await expect(newTool({num_rows: '4'})).rejects.toThrow(
+            "unexpected parameter 'num_rows' provided",
+          );
+        });
 
-        authToken1Getter = () => authToken1;
-        authToken2Getter = () => authToken2;
+        it('should successfully bind a parameter with bindParam and invoke', async () => {
+          const newTool = getNRowsTool.bindParam('num_rows', '3');
+          const response = await newTool(); // Invoke with no args
+          expect(response).toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).toContain('row3');
+          expect(response).not.toContain('row4');
+        });
+
+        it('should successfully bind parameters with bindParams and invoke', async () => {
+          const newTool = getNRowsTool.bindParams({num_rows: '3'});
+          const response = await newTool(); // Invoke with no args
+          expect(response).toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).toContain('row3');
+          expect(response).not.toContain('row4');
+        });
+
+        it('should successfully bind a synchronous function value', async () => {
+          const newTool = getNRowsTool.bindParams({num_rows: () => '1'});
+          const response = await newTool();
+          expect(response).toContain('row1');
+          expect(response).not.toContain('row2');
+        });
+
+        it('should successfully bind an asynchronous function value', async () => {
+          const asyncNumProvider = async () => {
+            await new Promise(resolve => setTimeout(resolve, 10));
+            return '1';
+          };
+
+          const newTool = getNRowsTool.bindParams({num_rows: asyncNumProvider});
+          const response = await newTool();
+          expect(response).toContain('row1');
+          expect(response).not.toContain('row2');
+        });
+
+        it('should successfully bind parameters at load time', async () => {
+          const tool = await commonToolboxClient.loadTool('get-n-rows', null, {
+            num_rows: '3',
+          });
+          const response = await tool();
+          expect(response).toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).toContain('row3');
+          expect(response).not.toContain('row4');
+        });
+
+        it('should throw an error when re-binding an existing parameter', () => {
+          const newTool = getNRowsTool.bindParam('num_rows', '1');
+          expect(() => {
+            newTool.bindParam('num_rows', '2');
+          }).toThrow(
+            "Cannot re-bind parameter: parameter 'num_rows' is already bound in tool 'get-n-rows'.",
+          );
+        });
+
+        it('should throw an error when binding a non-existent parameter', () => {
+          expect(() => {
+            getNRowsTool.bindParam('non_existent_param', '2');
+          }).toThrow(
+            "Unable to bind parameter: no parameter named 'non_existent_param' in tool 'get-n-rows'.",
+          );
+        });
       });
 
-      it('should fail when running a tool that does not require auth with auth provided', async () => {
-        await expect(
-          commonToolboxClient.loadTool('get-row-by-id', {
+      describe('Auth E2E Tests', () => {
+        // We isolate authToolboxClient to this block so that the global commonToolboxClient
+        // remains completely unauthenticated. If we mutate commonToolboxClient with auth
+        // claims here, subsequent test suites (like pagination) would inherit the auth state
+        // and mask bugs where unauthenticated requests should rightfully fail.
+        let authToolboxClient: ToolboxClient;
+        let authToken1: string;
+        let authToken2: string;
+        let authToken1Getter: () => string;
+        let authToken2Getter: () => string;
+
+        beforeEach(async () => {
+          authToolboxClient = new ToolboxClient(
+            testBaseUrl,
+            undefined,
+            undefined,
+            protocolVersion,
+          );
+        });
+
+        beforeAll(async () => {
+          if (!projectId) {
+            throw new Error(
+              'GOOGLE_CLOUD_PROJECT is not defined. Cannot run Auth E2E tests.',
+            );
+          }
+          authToken1 = await authTokenGetter(projectId, 'sdk_testing_client1');
+          authToken2 = await authTokenGetter(projectId, 'sdk_testing_client2');
+
+          authToken1Getter = () => authToken1;
+          authToken2Getter = () => authToken2;
+        });
+
+        it('should fail when running a tool that does not require auth with auth provided', async () => {
+          await expect(
+            authToolboxClient.loadTool('get-row-by-id', {
+              'my-test-auth': authToken2Getter,
+            }),
+          ).rejects.toThrow(
+            "Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
+          );
+        });
+
+        it('should fail when running a tool requiring auth without providing auth', async () => {
+          const tool = await authToolboxClient.loadTool('get-row-by-id-auth');
+          await expect(tool({id: '2'})).rejects.toThrow(
+            'One or more of the following authn services are required to invoke this tool: my-test-auth',
+          );
+        });
+
+        it('should fail when running a tool with incorrect auth', async () => {
+          const tool = await authToolboxClient.loadTool('get-row-by-id-auth');
+          const authTool = tool.addAuthTokenGetters({
             'my-test-auth': authToken2Getter,
-          }),
-        ).rejects.toThrow(
-          "Validation failed for tool 'get-row-by-id': unused auth tokens: my-test-auth",
-        );
-      });
-
-      it('should fail when running a tool requiring auth without providing auth', async () => {
-        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-        await expect(tool({id: '2'})).rejects.toThrow(
-          'One or more of the following authn services are required to invoke this tool: my-test-auth',
-        );
-      });
-
-      it('should fail when running a tool with incorrect auth', async () => {
-        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-        const authTool = tool.addAuthTokenGetters({
-          'my-test-auth': authToken2Getter,
-        });
-        try {
-          await authTool({id: '2'});
-        } catch (error) {
-          expect(error).toBeInstanceOf(AxiosError);
-          const axiosError = error as AxiosError;
-          expect(axiosError.response?.data).toEqual(
-            expect.objectContaining({
-              error: expect.objectContaining({
-                message: expect.stringMatching(
-                  /unauthorized|missing or invalid authentication header|unauthorized Tool call/,
-                ),
+          });
+          try {
+            await authTool({id: '2'});
+          } catch (error) {
+            expect(error).toBeInstanceOf(AxiosError);
+            const axiosError = error as AxiosError;
+            expect(axiosError.response?.data).toEqual(
+              expect.objectContaining({
+                error: expect.objectContaining({
+                  message: expect.stringMatching(
+                    /unauthorized|missing or invalid authentication header|unauthorized Tool call/,
+                  ),
+                }),
               }),
-            }),
+            );
+          }
+        });
+
+        it('should succeed when running a tool with correct auth', async () => {
+          const tool = await authToolboxClient.loadTool('get-row-by-id-auth');
+          const authTool = tool.addAuthTokenGetters({
+            'my-test-auth': authToken1Getter,
+          });
+          const response = await authTool({id: '2'});
+          expect(response).toContain('row2');
+        });
+
+        it('should succeed when running a tool with correct async auth', async () => {
+          const tool = await authToolboxClient.loadTool('get-row-by-id-auth');
+          const getAsyncToken = async () => {
+            return authToken1Getter();
+          };
+          const authTool = tool.addAuthTokenGetters({
+            'my-test-auth': getAsyncToken,
+          });
+          const response = await authTool({id: '2'});
+          expect(response).toContain('row2');
+        });
+
+        it('should fail when a tool with a param requiring auth is run without auth', async () => {
+          const tool = await authToolboxClient.loadTool(
+            'get-row-by-email-auth',
           );
-        }
-      });
-
-      it('should succeed when running a tool with correct auth', async () => {
-        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-        const authTool = tool.addAuthTokenGetters({
-          'my-test-auth': authToken1Getter,
+          await expect(tool()).rejects.toThrow(
+            'One or more of the following authn services are required to invoke this tool: my-test-auth',
+          );
         });
-        const response = await authTool({id: '2'});
-        expect(response).toContain('row2');
-      });
 
-      it('should succeed when running a tool with correct async auth', async () => {
-        const tool = await commonToolboxClient.loadTool('get-row-by-id-auth');
-        const getAsyncToken = async () => {
-          return authToken1Getter();
-        };
-        const authTool = tool.addAuthTokenGetters({
-          'my-test-auth': getAsyncToken,
+        it('should succeed when a tool with a param requiring auth is run with correct auth', async () => {
+          const tool = await authToolboxClient.loadTool(
+            'get-row-by-email-auth',
+            {
+              'my-test-auth': authToken1Getter,
+            },
+          );
+          const response = await tool();
+          expect(response).toContain('row4');
+          expect(response).toContain('row5');
+          expect(response).toContain('row6');
         });
-        const response = await authTool({id: '2'});
-        expect(response).toContain('row2');
-      });
 
-      it('should fail when a tool with a param requiring auth is run without auth', async () => {
-        const tool = await commonToolboxClient.loadTool(
-          'get-row-by-email-auth',
-        );
-        await expect(tool()).rejects.toThrow(
-          'One or more of the following authn services are required to invoke this tool: my-test-auth',
-        );
-      });
-
-      it('should succeed when a tool with a param requiring auth is run with correct auth', async () => {
-        const tool = await commonToolboxClient.loadTool(
-          'get-row-by-email-auth',
-          {
-            'my-test-auth': authToken1Getter,
-          },
-        );
-        const response = await tool();
-        expect(response).toContain('row4');
-        expect(response).toContain('row5');
-        expect(response).toContain('row6');
-      });
-
-      it('should fail when a tool with a param requiring auth is run with insufficient auth claims', async () => {
-        const tool = await commonToolboxClient.loadTool(
-          'get-row-by-content-auth',
-          {
-            'my-test-auth': authToken1Getter,
-          },
-        );
-        try {
-          await tool();
-          throw new Error('Expected tool invocation to fail');
-        } catch (error) {
-          expect(error).toBeInstanceOf(AxiosError);
-          const axiosError = error as AxiosError;
-          expect(axiosError.response?.data).toEqual(
-            expect.objectContaining({
-              error: expect.objectContaining({
-                message: expect.stringMatching(
-                  /provided parameters were invalid/,
-                ),
+        it('should fail when a tool with a param requiring auth is run with insufficient auth claims', async () => {
+          const tool = await authToolboxClient.loadTool(
+            'get-row-by-content-auth',
+            {
+              'my-test-auth': authToken1Getter,
+            },
+          );
+          try {
+            await tool();
+            throw new Error('Expected tool invocation to fail');
+          } catch (error) {
+            expect(error).toBeInstanceOf(AxiosError);
+            const axiosError = error as AxiosError;
+            expect(axiosError.response?.data).toEqual(
+              expect.objectContaining({
+                error: expect.objectContaining({
+                  message: expect.stringMatching(
+                    /provided parameters were invalid/,
+                  ),
+                }),
               }),
-            }),
+            );
+          }
+        });
+      });
+
+      describe('Optional Params E2E Tests', () => {
+        let searchRowsTool: ReturnType<typeof ToolboxTool>;
+
+        beforeAll(async () => {
+          searchRowsTool = await commonToolboxClient.loadTool('search-rows');
+        });
+
+        it('should correctly identify required and optional parameters in the schema', () => {
+          const paramSchema = searchRowsTool.getParamSchema();
+          const {shape} = paramSchema;
+
+          // Required param 'email'
+          expect(shape.email.isOptional()).toBe(false);
+          expect(shape.email.isNullable()).toBe(false);
+          expect(shape.email._def.typeName).toBe('ZodString');
+
+          // Optional param 'data'
+          expect(shape.data.isOptional()).toBe(true);
+          expect(shape.data.isNullable()).toBe(true);
+          {
+            let inner: ZodTypeAny = shape.data as unknown as ZodTypeAny;
+            while (
+              inner?._def?.typeName === 'ZodOptional' ||
+              inner?._def?.typeName === 'ZodNullable' ||
+              inner?._def?.typeName === 'ZodDefault'
+            ) {
+              inner = inner._def.innerType;
+            }
+            expect(inner._def.typeName).toBe('ZodString');
+          }
+
+          // Optional param 'id'
+          expect(shape.id.isOptional()).toBe(true);
+          expect(shape.id.isNullable()).toBe(true);
+          {
+            let inner: ZodTypeAny = shape.id as unknown as ZodTypeAny;
+            while (
+              inner?._def?.typeName === 'ZodOptional' ||
+              inner?._def?.typeName === 'ZodNullable' ||
+              inner?._def?.typeName === 'ZodDefault'
+            ) {
+              inner = inner._def.innerType;
+            }
+            expect(inner._def.typeName).toBe('ZodNumber');
+          }
+        });
+
+        it('should run tool with optional params omitted', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).not.toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
+        });
+
+        it('should run tool with optional data provided', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            data: 'row3',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).not.toContain('row2');
+          expect(response).toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
+        });
+
+        it('should run tool with optional data as null', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            data: null,
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).not.toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
+        });
+
+        it('should run tool with optional id provided', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: 1,
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toBe('null');
+        });
+
+        it('should run tool with optional id as null', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: null,
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).not.toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
+        });
+
+        it('should fail when a required param is missing', async () => {
+          await expect(searchRowsTool({id: 5, data: 'row5'})).rejects.toThrow(
+            /Argument validation failed for tool "search-rows":\s*- email: Required/,
           );
-        }
-      });
-    });
-
-    describe('Optional Params E2E Tests', () => {
-      let searchRowsTool: ReturnType<typeof ToolboxTool>;
-
-      beforeAll(async () => {
-        searchRowsTool = await commonToolboxClient.loadTool('search-rows');
-      });
-
-      it('should correctly identify required and optional parameters in the schema', () => {
-        const paramSchema = searchRowsTool.getParamSchema();
-        const {shape} = paramSchema;
-
-        // Required param 'email'
-        expect(shape.email.isOptional()).toBe(false);
-        expect(shape.email.isNullable()).toBe(false);
-        expect(shape.email._def.typeName).toBe('ZodString');
-
-        // Optional param 'data'
-        expect(shape.data.isOptional()).toBe(true);
-        expect(shape.data.isNullable()).toBe(true);
-        {
-          let inner: ZodTypeAny = shape.data as unknown as ZodTypeAny;
-          while (
-            inner?._def?.typeName === 'ZodOptional' ||
-            inner?._def?.typeName === 'ZodNullable' ||
-            inner?._def?.typeName === 'ZodDefault'
-          ) {
-            inner = inner._def.innerType;
-          }
-          expect(inner._def.typeName).toBe('ZodString');
-        }
-
-        // Optional param 'id'
-        expect(shape.id.isOptional()).toBe(true);
-        expect(shape.id.isNullable()).toBe(true);
-        {
-          let inner: ZodTypeAny = shape.id as unknown as ZodTypeAny;
-          while (
-            inner?._def?.typeName === 'ZodOptional' ||
-            inner?._def?.typeName === 'ZodNullable' ||
-            inner?._def?.typeName === 'ZodDefault'
-          ) {
-            inner = inner._def.innerType;
-          }
-          expect(inner._def.typeName).toBe('ZodNumber');
-        }
-      });
-
-      it('should run tool with optional params omitted', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).not.toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
-      });
 
-      it('should run tool with optional data provided', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          data: 'row3',
+        it('should fail when a required param is null', async () => {
+          await expect(
+            searchRowsTool({email: null, id: 5, data: 'row5'}),
+          ).rejects.toThrow(
+            /Argument validation failed for tool "search-rows":\s*- email: Expected string, received null/,
+          );
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).not.toContain('row2');
-        expect(response).toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
-      });
 
-      it('should run tool with optional data as null', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          data: null,
+        it('should run tool with all default params', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: 0,
+            data: 'row2',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).toContain('row2');
+          expect(response).not.toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).not.toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
-      });
 
-      it('should run tool with optional id provided', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: 1,
+        it('should run tool with all valid params', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: 3,
+            data: 'row3',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"email":"twishabansal@google.com"');
+          expect(response).not.toContain('row1');
+          expect(response).not.toContain('row2');
+          expect(response).toContain('row3');
+          expect(response).not.toContain('row4');
+          expect(response).not.toContain('row5');
+          expect(response).not.toContain('row6');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toBe('null');
-      });
 
-      it('should run tool with optional id as null', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: null,
+        it('should return null when called with a different email', async () => {
+          const response = await searchRowsTool({
+            email: 'anubhavdhawan@google.com',
+            id: 3,
+            data: 'row3',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toBe('null');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).not.toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
-      });
 
-      it('should fail when a required param is missing', async () => {
-        await expect(searchRowsTool({id: 5, data: 'row5'})).rejects.toThrow(
-          /Argument validation failed for tool "search-rows":\s*- email: Required/,
-        );
-      });
-
-      it('should fail when a required param is null', async () => {
-        await expect(
-          searchRowsTool({email: null, id: 5, data: 'row5'}),
-        ).rejects.toThrow(
-          /Argument validation failed for tool "search-rows":\s*- email: Expected string, received null/,
-        );
-      });
-
-      it('should run tool with all default params', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: 0,
-          data: 'row2',
+        it('should return null when called with different data', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: 3,
+            data: 'row4',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toBe('null');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).toContain('row2');
-        expect(response).not.toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
-      });
 
-      it('should run tool with all valid params', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: 3,
-          data: 'row3',
+        it('should return null when called with a different id', async () => {
+          const response = await searchRowsTool({
+            email: 'twishabansal@google.com',
+            id: 4,
+            data: 'row3',
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toBe('null');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"email":"twishabansal@google.com"');
-        expect(response).not.toContain('row1');
-        expect(response).not.toContain('row2');
-        expect(response).toContain('row3');
-        expect(response).not.toContain('row4');
-        expect(response).not.toContain('row5');
-        expect(response).not.toContain('row6');
       });
+      describe('Map/Object Params E2E Tests', () => {
+        let processDataTool: ReturnType<typeof ToolboxTool>;
 
-      it('should return null when called with a different email', async () => {
-        const response = await searchRowsTool({
-          email: 'anubhavdhawan@google.com',
-          id: 3,
-          data: 'row3',
+        beforeAll(async () => {
+          processDataTool = await commonToolboxClient.loadTool('process-data');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toBe('null');
-      });
 
-      it('should return null when called with different data', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: 3,
-          data: 'row4',
+        it('should correctly identify map/object parameters in the schema', () => {
+          const paramSchema = processDataTool.getParamSchema();
+          const baseArgs = {
+            execution_context: {env: 'prod'},
+            user_scores: {user1: 100},
+          };
+
+          // Test required untyped map (dict[str, Any])
+          expect(paramSchema.safeParse(baseArgs).success).toBe(true);
+          const argsWithoutExec = {...baseArgs};
+          delete (argsWithoutExec as Partial<typeof argsWithoutExec>)
+            .execution_context;
+          expect(paramSchema.safeParse(argsWithoutExec).success).toBe(false);
+
+          // Test required typed map (dict[str, int])
+          expect(
+            paramSchema.safeParse({
+              ...baseArgs,
+              user_scores: {user1: 'not-a-number'},
+            }).success,
+          ).toBe(false);
+
+          // Test optional typed map (dict[str, bool])
+          expect(
+            paramSchema.safeParse({
+              ...baseArgs,
+              feature_flags: {new_feature: true},
+            }).success,
+          ).toBe(true);
+          expect(
+            paramSchema.safeParse({...baseArgs, feature_flags: null}).success,
+          ).toBe(true);
+          expect(paramSchema.safeParse(baseArgs).success).toBe(true); // Omitted
         });
-        expect(typeof response).toBe('string');
-        expect(response).toBe('null');
-      });
 
-      it('should return null when called with a different id', async () => {
-        const response = await searchRowsTool({
-          email: 'twishabansal@google.com',
-          id: 4,
-          data: 'row3',
-        });
-        expect(typeof response).toBe('string');
-        expect(response).toBe('null');
-      });
-    });
-    describe('Map/Object Params E2E Tests', () => {
-      let processDataTool: ReturnType<typeof ToolboxTool>;
-
-      beforeAll(async () => {
-        processDataTool = await commonToolboxClient.loadTool('process-data');
-      });
-
-      it('should correctly identify map/object parameters in the schema', () => {
-        const paramSchema = processDataTool.getParamSchema();
-        const baseArgs = {
-          execution_context: {env: 'prod'},
-          user_scores: {user1: 100},
-        };
-
-        // Test required untyped map (dict[str, Any])
-        expect(paramSchema.safeParse(baseArgs).success).toBe(true);
-        const argsWithoutExec = {...baseArgs};
-        delete (argsWithoutExec as Partial<typeof argsWithoutExec>)
-          .execution_context;
-        expect(paramSchema.safeParse(argsWithoutExec).success).toBe(false);
-
-        // Test required typed map (dict[str, int])
-        expect(
-          paramSchema.safeParse({
-            ...baseArgs,
-            user_scores: {user1: 'not-a-number'},
-          }).success,
-        ).toBe(false);
-
-        // Test optional typed map (dict[str, bool])
-        expect(
-          paramSchema.safeParse({
-            ...baseArgs,
+        it('should run tool with valid map parameters', async () => {
+          const response = await processDataTool({
+            execution_context: {env: 'prod', id: 1234, user: 1234.5},
+            user_scores: {user1: 100, user2: 200},
             feature_flags: {new_feature: true},
-          }).success,
-        ).toBe(true);
-        expect(
-          paramSchema.safeParse({...baseArgs, feature_flags: null}).success,
-        ).toBe(true);
-        expect(paramSchema.safeParse(baseArgs).success).toBe(true); // Omitted
-      });
-
-      it('should run tool with valid map parameters', async () => {
-        const response = await processDataTool({
-          execution_context: {env: 'prod', id: 1234, user: 1234.5},
-          user_scores: {user1: 100, user2: 200},
-          feature_flags: {new_feature: true},
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain(
+            '"execution_context":{"env":"prod","id":1234,"user":1234.5}',
+          );
+          expect(response).toContain('"user_scores":{"user1":100,"user2":200}');
+          expect(response).toContain('"feature_flags":{"new_feature":true}');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain(
-          '"execution_context":{"env":"prod","id":1234,"user":1234.5}',
-        );
-        expect(response).toContain('"user_scores":{"user1":100,"user2":200}');
-        expect(response).toContain('"feature_flags":{"new_feature":true}');
-      });
 
-      it('should run tool with optional map param omitted', async () => {
-        const response = await processDataTool({
-          execution_context: {env: 'dev'},
-          user_scores: {user3: 300},
+        it('should run tool with optional map param omitted', async () => {
+          const response = await processDataTool({
+            execution_context: {env: 'dev'},
+            user_scores: {user3: 300},
+          });
+          expect(typeof response).toBe('string');
+          expect(response).toContain('"execution_context":{"env":"dev"}');
+          expect(response).toContain('"user_scores":{"user3":300}');
+          expect(response).toContain('"feature_flags":null');
         });
-        expect(typeof response).toBe('string');
-        expect(response).toContain('"execution_context":{"env":"dev"}');
-        expect(response).toContain('"user_scores":{"user3":300}');
-        expect(response).toContain('"feature_flags":null');
-      });
 
-      it('should fail when a map parameter has the wrong value type', async () => {
-        await expect(
-          processDataTool({
-            execution_context: {env: 'staging'},
-            user_scores: {user4: 'not-an-integer'},
-          }),
-        ).rejects.toThrow(
-          /user_scores\.user4: Expected number, received string/,
-        );
+        it('should fail when a map parameter has the wrong value type', async () => {
+          await expect(
+            processDataTool({
+              execution_context: {env: 'staging'},
+              user_scores: {user4: 'not-an-integer'},
+            }),
+          ).rejects.toThrow(
+            /user_scores\.user4: Expected number, received string/,
+          );
+        });
       });
+    },
+  );
+
+  describe(`Protocol Configuration E2E Tests against ${testBaseUrl}`, () => {
+    it('should default to the correct protocol when none is specified', async () => {
+      const client = new ToolboxClient(testBaseUrl);
+
+      const tool = await client.loadTool('get-n-rows');
+      const response = await tool({num_rows: '1'});
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
     });
-  },
-);
 
-describe('ToolboxClient E2E Protocol Negotiation Fallback', () => {
-  it('should successfully fallback to a supported version when draft specs are disabled on the server', async () => {
-    const testBaseUrl = 'http://localhost:5000';
-    const client = new ToolboxClient(
-      testBaseUrl,
-      undefined,
-      undefined,
-      Protocol.MCP_DRAFT_2026_v1,
-    );
+    if (testBaseUrl === LEGACY_SERVER_URL) {
+      it('should fallback to an older protocol against a server that does not support the draft version', async () => {
+        const session = axios.create();
+        const postSpy = jest.spyOn(session, 'post');
 
-    const tool = await client.loadTool('get-n-rows');
-    expect(tool.getName()).toBe('get-n-rows');
+        const client = new ToolboxClient(
+          testBaseUrl,
+          session,
+          undefined,
+          Protocol.MCP_DRAFT_2026_v1,
+        );
+
+        const tool = await client.loadTool('get-n-rows');
+        const response = await tool({num_rows: '1'});
+        expect(typeof response).toBe('string');
+        expect(response).toContain('row1');
+
+        expect(postSpy).toHaveBeenCalledTimes(5);
+
+        // Call 1: Draft tools/list (fails)
+        const call1 = postSpy.mock.calls[0];
+        expect(call1[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
+        expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_DRAFT_2026_v1,
+        );
+
+        // Call 2: Stateful Initialize (succeeds)
+        const call2 = postSpy.mock.calls[1];
+        expect(call2[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect((call2[1] as Record<string, unknown>).method).toBe('initialize');
+        expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_v20251125,
+        );
+
+        // Call 3: Stateful Initialized Notification (succeeds)
+        const call3 = postSpy.mock.calls[2];
+        expect(call3[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect((call3[1] as Record<string, unknown>).method).toBe(
+          'notifications/initialized',
+        );
+        expect(call3[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_v20251125,
+        );
+
+        // Call 4: Stateful tools/list (succeeds)
+        const call4 = postSpy.mock.calls[3];
+        expect(call4[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect((call4[1] as Record<string, unknown>).method).toBe('tools/list');
+        expect(call4[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_v20251125,
+        );
+
+        // Call 5: Stateful tools/call (succeeds)
+        const call5 = postSpy.mock.calls[4];
+        expect(call5[0]).toBe(`${LEGACY_SERVER_URL}/mcp/`);
+        expect((call5[1] as Record<string, unknown>).method).toBe('tools/call');
+        expect(call5[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_v20251125,
+        );
+      });
+    } else if (testBaseUrl === DRAFT_SERVER_URL) {
+      it('should successfully connect using the draft version without fallback', async () => {
+        const session = axios.create();
+        const postSpy = jest.spyOn(session, 'post');
+
+        const client = new ToolboxClient(
+          testBaseUrl,
+          session,
+          undefined,
+          Protocol.MCP_DRAFT_2026_v1,
+        );
+
+        const tool = await client.loadTool('get-n-rows');
+        const response = await tool({num_rows: '1'});
+        expect(typeof response).toBe('string');
+        expect(response).toContain('row1');
+
+        expect(postSpy).toHaveBeenCalledTimes(2);
+
+        // Call 1: Draft tools/list (succeeds)
+        const call1 = postSpy.mock.calls[0];
+        expect(call1[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
+        expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_DRAFT_2026_v1,
+        );
+
+        // Call 2: Draft tools/call (succeeds)
+        const call2 = postSpy.mock.calls[1];
+        expect(call2[0]).toBe(`${DRAFT_SERVER_URL}/mcp/`);
+        expect((call2[1] as Record<string, unknown>).method).toBe('tools/call');
+        expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
+          Protocol.MCP_DRAFT_2026_v1,
+        );
+      });
+    }
   });
 });

--- a/packages/toolbox-core/test/e2e/types.ts
+++ b/packages/toolbox-core/test/e2e/types.ts
@@ -18,6 +18,7 @@ import {ChildProcess} from 'child_process';
 export type CustomGlobal = typeof globalThis & {
   __TOOLS_FILE_PATH__?: string;
   __TOOLBOX_SERVER_PROCESS__?: ChildProcess;
+  __TOOLBOX_SERVER_PROCESS_2__?: ChildProcess;
   __SERVER_TEARDOWN_INITIATED__?: boolean;
   __GOOGLE_CLOUD_PROJECT__?: string;
 };

--- a/packages/toolbox-core/test/mcp/test.v20241105.ts
+++ b/packages/toolbox-core/test/mcp/test.v20241105.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
 import {McpHttpTransportV20241105} from '../../src/toolbox_core/mcp/v20241105/mcp.js';
 import {jest} from '@jest/globals';
 import axios, {AxiosInstance} from 'axios';
@@ -217,7 +218,7 @@ describe('McpHttpTransportV20241105', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       await expect(transport.toolsList()).rejects.toThrow(
-        /MCP version mismatch/,
+        new ProtocolNegotiationError('2023-01-01' as Protocol),
       );
       errorSpy.mockRestore();
     });

--- a/packages/toolbox-core/test/mcp/test.v20250326.ts
+++ b/packages/toolbox-core/test/mcp/test.v20250326.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
 import {McpHttpTransportV20250326} from '../../src/toolbox_core/mcp/v20250326/mcp.js';
 import {jest} from '@jest/globals';
 import axios, {AxiosInstance} from 'axios';
@@ -220,7 +221,7 @@ describe('McpHttpTransportV20250326', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       await expect(transport.toolsList()).rejects.toThrow(
-        /MCP version mismatch/,
+        new ProtocolNegotiationError('2023-01-01' as Protocol),
       );
       errorSpy.mockRestore();
     });

--- a/packages/toolbox-core/test/mcp/test.v20250618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20250618.ts
@@ -231,6 +231,66 @@ describe('McpHttpTransportV20250618', () => {
       errorSpy.mockRestore();
     });
 
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2024-11-05'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw error if tools capability missing', async () => {
       const initResponse = {
         data: {
@@ -921,6 +981,62 @@ describe('McpHttpTransportV20250618', () => {
   });
 
   describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-03-26'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-03-26'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
       const rpcError = {
         jsonrpc: '2.0',

--- a/packages/toolbox-core/test/mcp/test.v20250618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20250618.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
 import {McpHttpTransportV20250618} from '../../src/toolbox_core/mcp/v20250618/mcp.js';
 import {jest} from '@jest/globals';
-import axios, {AxiosInstance} from 'axios';
+import axios, {AxiosInstance, AxiosError} from 'axios';
 
 import {Protocol} from '../../src/toolbox_core/protocol.js';
 
@@ -225,7 +226,7 @@ describe('McpHttpTransportV20250618', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       await expect(transport.toolsList()).rejects.toThrow(
-        /MCP version mismatch/,
+        new ProtocolNegotiationError('2023-01-01' as Protocol),
       );
       errorSpy.mockRestore();
     });
@@ -916,6 +917,90 @@ describe('McpHttpTransportV20250618', () => {
       );
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32004,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-03-26'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns invalid protocol version string', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250326),
+      );
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/toolbox-core/test/mcp/test.v20251125.ts
+++ b/packages/toolbox-core/test/mcp/test.v20251125.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
 import {McpHttpTransportV20251125} from '../../src/toolbox_core/mcp/v20251125/mcp.js';
 import {jest} from '@jest/globals';
-import axios, {AxiosInstance} from 'axios';
+import axios, {AxiosInstance, AxiosError} from 'axios';
 
 import {Protocol} from '../../src/toolbox_core/protocol.js';
 
@@ -225,7 +226,7 @@ describe('McpHttpTransportV20251125', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       await expect(transport.toolsList()).rejects.toThrow(
-        /MCP version mismatch/,
+        new ProtocolNegotiationError('2023-01-01' as Protocol),
       );
       errorSpy.mockRestore();
     });
@@ -916,6 +917,90 @@ describe('McpHttpTransportV20251125', () => {
       );
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32004,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-06-18'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns invalid protocol version string', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/toolbox-core/test/mcp/test.v20251125.ts
+++ b/packages/toolbox-core/test/mcp/test.v20251125.ts
@@ -231,6 +231,66 @@ describe('McpHttpTransportV20251125', () => {
       errorSpy.mockRestore();
     });
 
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2024-11-05'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const errorObj = new Error(
+        'Request failed with status code 400',
+      ) as unknown as Record<string, unknown>;
+      errorObj.isAxiosError = true;
+      errorObj.response = {
+        status: 400,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      };
+
+      mockSession.post.mockRejectedValueOnce(errorObj);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw error if tools capability missing', async () => {
       const initResponse = {
         data: {
@@ -921,6 +981,62 @@ describe('McpHttpTransportV20251125', () => {
   });
 
   describe('version negotiation fallback', () => {
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-06-18'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-06-18'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20250618),
+      );
+      errorSpy.mockRestore();
+    });
+
     it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
       const rpcError = {
         jsonrpc: '2.0',

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -90,7 +90,7 @@ describe('McpHttpTransportV20260618', () => {
           method: 'tools/list',
           params: {
             _meta: expect.objectContaining({
-              protocolVersion: 'DRAFT-2026-v1',
+              'io.modelcontextprotocol/protocolVersion': 'DRAFT-2026-v1',
             }),
           },
         }),
@@ -245,7 +245,7 @@ describe('McpHttpTransportV20260618', () => {
             name: 'testTool',
             arguments: {arg: 'val'},
             _meta: expect.objectContaining({
-              protocolVersion: 'DRAFT-2026-v1',
+              'io.modelcontextprotocol/protocolVersion': 'DRAFT-2026-v1',
             }),
           },
         }),

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -1,0 +1,549 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {McpHttpTransportV20260618} from '../../src/toolbox_core/mcp/v20260618/mcp.js';
+import {jest} from '@jest/globals';
+import axios, {AxiosInstance, AxiosError} from 'axios';
+
+import {Protocol} from '../../src/toolbox_core/protocol.js';
+import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios') as {
+    default: typeof import('axios');
+  };
+  return {
+    __esModule: true,
+    ...actual,
+    default: {
+      ...actual.default,
+      create: jest.fn(),
+    },
+  };
+});
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('McpHttpTransportV20260618', () => {
+  const testBaseUrl = 'http://test.loc';
+  let mockSession: jest.Mocked<AxiosInstance>;
+  let transport: McpHttpTransportV20260618;
+  let consoleWarnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    mockSession = {
+      get: jest.fn(),
+      post: jest.fn(),
+      defaults: {headers: {}},
+      interceptors: {
+        request: {use: jest.fn()},
+        response: {use: jest.fn()},
+      },
+    } as unknown as jest.Mocked<AxiosInstance>;
+
+    mockedAxios.create.mockReturnValue(mockSession);
+    transport = new McpHttpTransportV20260618(
+      testBaseUrl,
+      mockSession,
+      Protocol.MCP_DRAFT_2026_v1,
+    );
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('initialization', () => {
+    it('should not perform initialize handshake (no-op)', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      await transport.toolsList();
+
+      // Only tools/list request should be made, no initialize or initialized notification
+      expect(mockSession.post).toHaveBeenCalledTimes(1);
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        `${testBaseUrl}/mcp/`,
+        expect.objectContaining({
+          method: 'tools/list',
+          params: {
+            _meta: expect.objectContaining({
+              protocolVersion: 'DRAFT-2026-v1',
+            }),
+          },
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('toolsList', () => {
+    it('should return converted tools', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [
+              {
+                name: 'testTool',
+                description: 'A test tool',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    x: {type: 'string'},
+                  },
+                },
+              },
+            ],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const manifest = await transport.toolsList();
+
+      expect(manifest.tools['testTool']).toBeDefined();
+      expect(manifest.tools['testTool'].description).toBe('A test tool');
+      expect(manifest.tools['testTool'].parameters).toBeDefined();
+    });
+
+    it('should throw if toolsList returns no response (204)', async () => {
+      mockSession.post.mockResolvedValueOnce({
+        status: 204,
+        data: null,
+      });
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolsList()).rejects.toThrow(
+        'Failed to list tools: No response from server.',
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('toolGet', () => {
+    it('should return specific tool manifest', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            tools: [
+              {
+                name: 'targetTool',
+                description: 'desc',
+                inputSchema: {type: 'object'},
+              },
+              {
+                name: 'otherTool',
+                description: 'desc2',
+                inputSchema: {type: 'object'},
+              },
+            ],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const manifest = await transport.toolGet('targetTool');
+
+      expect(manifest.tools).toHaveProperty('targetTool');
+      expect(Object.keys(manifest.tools).length).toBe(1);
+    });
+
+    it('should throw if tool not found', async () => {
+      const listResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {tools: []},
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(listResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolGet('missing')).rejects.toThrow(
+        /Tool 'missing' not found/,
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('toolInvoke', () => {
+    it('should invoke tool and return text content', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '2',
+          result: {
+            content: [{type: 'text', text: 'Result output'}],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      const result = await transport.toolInvoke('testTool', {arg: 'val'}, {});
+
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        `${testBaseUrl}/mcp/`,
+        expect.objectContaining({
+          method: 'tools/call',
+          params: {
+            name: 'testTool',
+            arguments: {arg: 'val'},
+            _meta: expect.objectContaining({
+              protocolVersion: 'DRAFT-2026-v1',
+            }),
+          },
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+          }),
+        }),
+      );
+      expect(result).toBe('Result output');
+    });
+
+    it('should handle JSON-RPC errors', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const errorResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '2',
+          error: {
+            code: -32601,
+            message: 'Method not found',
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(errorResponse);
+
+      await expect(transport.toolInvoke('badTool', {}, {})).rejects.toThrow(
+        /MCP request failed with code -32601: Method not found/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should handle HTTP errors', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const httpErrorResponse = {
+        data: 'Server Error',
+        status: 500,
+        statusText: 'Internal Server Error',
+      };
+
+      mockSession.post.mockResolvedValueOnce(httpErrorResponse);
+
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        /API request failed with status 500/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw if toolInvoke returns no response (204)', async () => {
+      mockSession.post.mockResolvedValueOnce({
+        status: 204,
+        data: null,
+      });
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        "Failed to invoke tool 'testTool': No response from server.",
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw if toolInvoke returns invalid JSON-RPC structure', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const invalidResponse = {
+        data: {
+          foo: 'bar',
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invalidResponse);
+
+      await expect(transport.toolInvoke('testTool', {}, {})).rejects.toThrow(
+        'Failed to parse JSON-RPC response structure',
+      );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('version negotiation', () => {
+    it('should throw ProtocolNegotiationError if server returns code -32022 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32022,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-11-25'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns invalid protocol version string', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw Error if server returns code -32022 with no mutually supported version', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32022,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['invalid-older-version'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw Error if server returns invalid protocol version but no fallback remains', async () => {
+      const oldestTransport = new McpHttpTransportV20260618(
+        testBaseUrl,
+        mockSession,
+        Protocol.MCP_v20241105,
+      );
+
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: 'invalid protocol version',
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(oldestTransport.toolsList()).rejects.toThrow(
+        /no fallback versions remain/,
+      );
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('security and headers', () => {
+    it('should warn if sending headers over HTTP', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {content: []},
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      await transport.toolInvoke(
+        'testTool',
+        {arg: 'val'},
+        {Authorization: 'Bearer token'},
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'This connection is using HTTP. To prevent credential exposure, please ensure all communication is sent over HTTPS.',
+        ),
+      );
+    });
+
+    it('should not warn if using HTTPS', async () => {
+      const invokeResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {content: []},
+        },
+        status: 200,
+      };
+      // Create HTTPS transport
+      const httpsTransport = new McpHttpTransportV20260618(
+        'https://secure.test.loc',
+        mockSession,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      mockSession.post.mockResolvedValueOnce(invokeResponse);
+
+      await httpsTransport.toolInvoke(
+        'testTool',
+        {arg: 'val'},
+        {Authorization: 'Bearer token'},
+      );
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -382,19 +382,7 @@ describe('McpHttpTransportV20260618', () => {
       errorSpy.mockRestore();
     });
 
-    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
-      const rpcError = {
-        jsonrpc: '2.0',
-        id: '1',
-        error: {
-          code: -32004,
-          message: 'Unsupported protocol version',
-          data: {
-            supported: ['2025-11-25'],
-          },
-        },
-      };
-
+    it('should throw ProtocolNegotiationError on -32004 with supported array', async () => {
       const config =
         {} as unknown as import('axios').InternalAxiosRequestConfig;
       const response = {
@@ -402,7 +390,15 @@ describe('McpHttpTransportV20260618', () => {
         statusText: 'Bad Request',
         headers: {},
         config,
-        data: rpcError,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
       } as unknown as import('axios').AxiosResponse;
 
       const axiosError = new AxiosError(
@@ -422,7 +418,151 @@ describe('McpHttpTransportV20260618', () => {
       await expect(transport.toolsList()).rejects.toThrow(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
+      errorSpy.mockRestore();
+    });
 
+    it('should throw ProtocolNegotiationError on -32004 with no intersection', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: {
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32022 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns HTTP 200 with code -32004 and supported list', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['2025-11-25'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw error if server returns HTTP 200 with code -32004 and no intersection', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: {
+            code: -32004,
+            message: 'Protocol version not supported',
+            data: {
+              supported: ['9999-01-01'],
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        /No mutually supported protocol version/,
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns HTTP 200 with invalid protocol version string', async () => {
+      const initResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          error: 'invalid protocol version',
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(initResponse);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
       errorSpy.mockRestore();
     });
 
@@ -459,6 +599,70 @@ describe('McpHttpTransportV20260618', () => {
 
       await expect(transport.toolsList()).rejects.toThrow(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns a raw plain text string error (invalid protocol version)', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: 'invalid protocol version',
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError (legacy fallback) if server returns a raw plain text string error (invalid protocol version / fallback)', async () => {
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: 'invalid protocol version',
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        ProtocolNegotiationError,
       );
 
       errorSpy.mockRestore();

--- a/packages/toolbox-core/test/mcp/test.v20260618.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260618.ts
@@ -131,6 +131,20 @@ describe('McpHttpTransportV20260618', () => {
 
       const manifest = await transport.toolsList();
 
+      expect(mockSession.post).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'MCP-Protocol-Version': 'DRAFT-2026-v1',
+            'Mcp-Method': 'tools/list',
+          }),
+        }),
+      );
+      expect(
+        mockSession.post.mock.calls[0][2]?.headers?.['Mcp-Name'],
+      ).toBeUndefined();
+
       expect(manifest.tools['testTool']).toBeDefined();
       expect(manifest.tools['testTool'].description).toBe('A test tool');
       expect(manifest.tools['testTool'].parameters).toBeDefined();
@@ -238,6 +252,8 @@ describe('McpHttpTransportV20260618', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'MCP-Protocol-Version': 'DRAFT-2026-v1',
+            'Mcp-Method': 'tools/call',
+            'Mcp-Name': 'testTool',
           }),
         }),
       );
@@ -360,7 +376,51 @@ describe('McpHttpTransportV20260618', () => {
         .mockImplementation(() => {});
 
       await expect(transport.toolsList()).rejects.toThrow(
-        ProtocolNegotiationError,
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should throw ProtocolNegotiationError if server returns code -32004 with supported list', async () => {
+      const rpcError = {
+        jsonrpc: '2.0',
+        id: '1',
+        error: {
+          code: -32004,
+          message: 'Unsupported protocol version',
+          data: {
+            supported: ['2025-11-25'],
+          },
+        },
+      };
+
+      const config =
+        {} as unknown as import('axios').InternalAxiosRequestConfig;
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config,
+        data: rpcError,
+      } as unknown as import('axios').AxiosResponse;
+
+      const axiosError = new AxiosError(
+        'Request failed with status code 400',
+        'ERR_BAD_REQUEST',
+        config,
+        {},
+        response,
+      );
+
+      mockSession.post.mockRejectedValueOnce(axiosError);
+
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      await expect(transport.toolsList()).rejects.toThrow(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
 
       errorSpy.mockRestore();
@@ -398,7 +458,7 @@ describe('McpHttpTransportV20260618', () => {
         .mockImplementation(() => {});
 
       await expect(transport.toolsList()).rejects.toThrow(
-        ProtocolNegotiationError,
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
       );
 
       errorSpy.mockRestore();

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -14,7 +14,11 @@
 
 import {jest} from '@jest/globals';
 import {ITransport} from '../src/toolbox_core/transport.types.js';
-import {ZodManifest, Protocol} from '../src/toolbox_core/protocol.js';
+import {
+  ZodManifest,
+  Protocol,
+  getSupportedMcpVersions,
+} from '../src/toolbox_core/protocol.js';
 import type {ToolboxClient as ToolboxClientType} from '../src/toolbox_core/client.js';
 import {ToolboxClient} from '../src/toolbox_core/client.js';
 import {McpHttpTransportV20241105} from '../src/toolbox_core/mcp/v20241105/mcp.js';
@@ -28,6 +32,7 @@ import {ProtocolNegotiationError} from '../src/toolbox_core/errorUtils.js';
 class MockTransport implements ITransport {
   readonly baseUrl: string;
   protocolVersion = Protocol.MCP;
+  supportedProtocols?: Protocol[];
   toolGet: jest.MockedFunction<ITransport['toolGet']>;
   toolsList: jest.MockedFunction<ITransport['toolsList']>;
   toolInvoke: jest.MockedFunction<ITransport['toolInvoke']>;
@@ -77,6 +82,19 @@ jest.mock('../src/toolbox_core/mcp/v20260618/mcp', () => {
   return {
     __esModule: true,
     McpHttpTransportV20260618: jest.fn(),
+  };
+});
+
+// Mock the protocol module
+jest.mock('../src/toolbox_core/protocol', () => {
+  const original = jest.requireActual(
+    '../src/toolbox_core/protocol',
+  ) as unknown as Record<string, unknown>;
+  return {
+    ...original,
+    getSupportedMcpVersions: jest.fn(() =>
+      (original.getSupportedMcpVersions as () => Protocol[])(),
+    ),
   };
 });
 
@@ -257,7 +275,33 @@ describe('ToolboxClient', () => {
           undefined,
           'unknown-protocol' as Protocol,
         );
-      }).toThrow('Unsupported protocol version: unknown-protocol');
+      }).toThrow(/Invalid protocol version 'unknown-protocol'/);
+    });
+
+    it('should throw error for empty protocol array', () => {
+      expect(() => {
+        new ToolboxClient(testBaseUrl, undefined, undefined, []);
+      }).toThrow('Protocol array cannot be empty');
+    });
+
+    it('should throw error if any protocol in array is unsupported', () => {
+      expect(() => {
+        new ToolboxClient(testBaseUrl, undefined, undefined, [
+          '2025-11-25',
+          'unknown-protocol' as Protocol,
+        ]);
+      }).toThrow(/Invalid protocol version 'unknown-protocol'/);
+    });
+
+    it('should pass supportedProtocols to transport', () => {
+      client = new ToolboxClient(testBaseUrl, undefined, undefined, [
+        '2025-11-25',
+        'DRAFT-2026-v1',
+      ]);
+      expect(mockTransport.supportedProtocols).toEqual([
+        'DRAFT-2026-v1',
+        '2025-11-25',
+      ]);
     });
 
     it('should pass client name and version to transport', () => {
@@ -664,7 +708,9 @@ describe('ToolboxClient', () => {
   describe('Protocol Fallback', () => {
     it('should fall back to supported version in loadTool when transport throws ProtocolNegotiationError', async () => {
       const draftTransport = new MockTransport(testBaseUrl);
+      draftTransport.protocolVersion = Protocol.MCP_DRAFT;
       const fallbackTransport = new MockTransport(testBaseUrl);
+      fallbackTransport.protocolVersion = Protocol.MCP_v20251125;
 
       draftTransport.toolGet.mockRejectedValueOnce(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
@@ -695,7 +741,7 @@ describe('ToolboxClient', () => {
         testBaseUrl,
         undefined,
         undefined,
-        Protocol.MCP_DRAFT_2026_v1,
+        Protocol.MCP_DRAFT,
       );
 
       const tool = await client.loadTool('testTool');
@@ -707,7 +753,9 @@ describe('ToolboxClient', () => {
 
     it('should fall back to supported version in loadToolset when transport throws ProtocolNegotiationError', async () => {
       const draftTransport = new MockTransport(testBaseUrl);
+      draftTransport.protocolVersion = Protocol.MCP_DRAFT;
       const fallbackTransport = new MockTransport(testBaseUrl);
+      fallbackTransport.protocolVersion = Protocol.MCP_v20251125;
 
       draftTransport.toolsList.mockRejectedValueOnce(
         new ProtocolNegotiationError(Protocol.MCP_v20251125),
@@ -738,7 +786,7 @@ describe('ToolboxClient', () => {
         testBaseUrl,
         undefined,
         undefined,
-        Protocol.MCP_DRAFT_2026_v1,
+        Protocol.MCP_DRAFT,
       );
 
       const tools = await client.loadToolset('set');
@@ -747,6 +795,146 @@ describe('ToolboxClient', () => {
       expect(draftTransport.toolsList).toHaveBeenCalledTimes(1);
       expect(fallbackTransport.toolsList).toHaveBeenCalledTimes(1);
       expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Fallback Logic', () => {
+    let mockTransport1: MockTransport;
+    let mockTransport2: MockTransport;
+
+    beforeEach(() => {
+      mockTransport1 = new MockTransport(testBaseUrl);
+      mockTransport2 = new MockTransport(testBaseUrl);
+    });
+
+    it('should fallback when ProtocolNegotiationError is thrown (The Cascading Fallback Test)', async () => {
+      // Setup first transport to throw error with fallback version
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      // Setup second transport to succeed
+      mockTransport2.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {testTool: {description: 'test', parameters: []}},
+      });
+      mockTransport2.protocolVersion = Protocol.MCP_v20241105;
+
+      // The client uses the Latest/Draft by default initially.
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+      (McpHttpTransportV20241105 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport2,
+      );
+
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20241105,
+      ]);
+
+      const tools = await client.loadToolset('test');
+
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport2.toolsList).toHaveBeenCalledTimes(1);
+      expect(tools.length).toBe(1);
+      expect(client.protocolVersion).toBe(Protocol.MCP_v20241105);
+    });
+
+    it('should handle multi-step cascading fallbacks across three transport versions (Draft -> 20251125 -> 20241105)', async () => {
+      const mockTransport1 = new MockTransport(testBaseUrl);
+      mockTransport1.protocolVersion = Protocol.MCP_DRAFT;
+      const mockTransport2 = new MockTransport(testBaseUrl);
+      mockTransport2.protocolVersion = Protocol.MCP_v20251125;
+      const mockTransport3 = new MockTransport(testBaseUrl);
+
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+      mockTransport2.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+      mockTransport3.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {testTool: {description: 'test', parameters: []}},
+      });
+      mockTransport3.protocolVersion = Protocol.MCP_v20241105;
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport2,
+      );
+      (McpHttpTransportV20241105 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport3,
+      );
+
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20251125,
+        Protocol.MCP_v20241105,
+      ]);
+
+      const tools = await client.loadToolset('test');
+
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport2.toolsList).toHaveBeenCalledTimes(1);
+      expect(mockTransport3.toolsList).toHaveBeenCalledTimes(1);
+      expect(tools.length).toBe(1);
+      expect(client.protocolVersion).toBe(Protocol.MCP_v20241105);
+    });
+
+    it('should throw an error if server returns unsupported old version (The Strict Constraint Test)', async () => {
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20241105),
+      );
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+
+      // Client only supports Draft and 20251125, but server threw 20241105
+      const client = new ToolboxClient(testBaseUrl, null, null, [
+        Protocol.MCP_DRAFT,
+        Protocol.MCP_v20251125,
+      ]);
+
+      await expect(client.loadToolset('test')).rejects.toThrow(
+        'No mutually supported protocol version',
+      );
+    });
+
+    it('should throw ProtocolNegotiationError if fallback version is equal to current transport version (infinite loop guard)', async () => {
+      mockTransport1.protocolVersion = Protocol.MCP_DRAFT;
+      mockTransport1.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_DRAFT),
+      );
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => mockTransport1,
+      );
+
+      const client = new ToolboxClient(
+        testBaseUrl,
+        null,
+        null,
+        Protocol.MCP_DRAFT,
+      );
+
+      await expect(client.loadToolset('test')).rejects.toThrow(
+        ProtocolNegotiationError,
+      );
+      expect(mockTransport1.toolsList).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw an error if transport creation hits default block with unsupported protocol version', () => {
+      (getSupportedMcpVersions as jest.Mock).mockReturnValueOnce([
+        '9999-01-01' as Protocol,
+      ]);
+
+      expect(() => {
+        new ToolboxClient(testBaseUrl, null, null, '9999-01-01' as Protocol);
+      }).toThrow('Unsupported MCP protocol version: 9999-01-01');
     });
   });
 });

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -14,11 +14,7 @@
 
 import {jest} from '@jest/globals';
 import {ITransport} from '../src/toolbox_core/transport.types.js';
-import {
-  ZodManifest,
-  Protocol,
-  MCP_LATEST,
-} from '../src/toolbox_core/protocol.js';
+import {ZodManifest, Protocol} from '../src/toolbox_core/protocol.js';
 import type {ToolboxClient as ToolboxClientType} from '../src/toolbox_core/client.js';
 import {ToolboxClient} from '../src/toolbox_core/client.js';
 import {McpHttpTransportV20241105} from '../src/toolbox_core/mcp/v20241105/mcp.js';
@@ -31,6 +27,7 @@ import {ProtocolNegotiationError} from '../src/toolbox_core/errorUtils.js';
 // --- Mock Transport Implementation ---
 class MockTransport implements ITransport {
   readonly baseUrl: string;
+  protocolVersion = Protocol.MCP;
   toolGet: jest.MockedFunction<ITransport['toolGet']>;
   toolsList: jest.MockedFunction<ITransport['toolsList']>;
   toolInvoke: jest.MockedFunction<ITransport['toolInvoke']>;
@@ -141,9 +138,6 @@ describe('ToolboxClient', () => {
     });
 
     it('should initialize with MCP transport (explicit) when specified', () => {
-      const consoleSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
       client = new ToolboxClient(
         testBaseUrl,
         undefined,
@@ -157,12 +151,6 @@ describe('ToolboxClient', () => {
         undefined,
         undefined,
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `A newer version of MCP: ${MCP_LATEST} is available`,
-        ),
-      );
-      consoleSpy.mockRestore();
     });
 
     it('should initialize with MCP v20241105 transport when specified', () => {
@@ -519,14 +507,35 @@ describe('ToolboxClient', () => {
   describe('Insecure Protocol Warnings', () => {
     let consoleSpy: jest.SpiedFunction<typeof console.warn>;
     const httpUrl = 'http://api.example.com';
+    let httpTransport: MockTransport;
+    let httpsTransport: MockTransport;
 
     beforeEach(() => {
       consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      // We need to ensure the transport has the HTTP URL for these tests
-      const httpTransport = new MockTransport(httpUrl);
-      // We mock the implementation for the default MCP version used by ToolboxClient
+      httpTransport = new MockTransport(httpUrl);
+      httpsTransport = new MockTransport(testBaseUrl);
+
+      const mockImpl = (url: unknown) => {
+        if (typeof url !== 'string') {
+          throw new Error('Expected url to be string');
+        }
+        return url.startsWith('https:') ? httpsTransport : httpTransport;
+      };
+
+      (McpHttpTransportV20241105 as unknown as jest.Mock).mockImplementation(
+        mockImpl,
+      );
+      (McpHttpTransportV20250326 as unknown as jest.Mock).mockImplementation(
+        mockImpl,
+      );
       (McpHttpTransportV20250618 as unknown as jest.Mock).mockImplementation(
-        () => httpTransport,
+        mockImpl,
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        mockImpl,
+      );
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        mockImpl,
       );
     });
 
@@ -540,7 +549,6 @@ describe('ToolboxClient', () => {
         expect.stringContaining('This connection is using HTTP'),
       );
     });
-
     it('should NOT warn when initializing with HTTPS and client headers', () => {
       new ToolboxClient(testBaseUrl, undefined, {'X-Test': 'val'});
       expect(consoleSpy).not.toHaveBeenCalledWith(
@@ -549,7 +557,6 @@ describe('ToolboxClient', () => {
     });
 
     it('should warn in loadTool with HTTP and auth tokens', async () => {
-      const httpTransport = new MockTransport(httpUrl);
       httpTransport.toolGet.mockResolvedValue({
         serverVersion: '1.0.0',
         tools: {
@@ -560,9 +567,6 @@ describe('ToolboxClient', () => {
           },
         },
       });
-      (McpHttpTransportV20250618 as unknown as jest.Mock).mockImplementation(
-        () => httpTransport,
-      );
 
       client = new ToolboxClient(httpUrl);
       await client.loadTool('testTool', {auth: () => 'token'});
@@ -570,10 +574,7 @@ describe('ToolboxClient', () => {
         expect.stringContaining('This connection is using HTTP'),
       );
     });
-
     it('should NOT warn in loadTool with HTTPS and auth tokens', async () => {
-      // Re-setup mock with HTTPS url
-      const httpsTransport = new MockTransport(testBaseUrl);
       httpsTransport.toolGet.mockResolvedValue({
         serverVersion: '1.0.0',
         tools: {
@@ -584,9 +585,6 @@ describe('ToolboxClient', () => {
           },
         },
       });
-      (McpHttpTransportV20250618 as unknown as jest.Mock).mockImplementation(
-        () => httpsTransport,
-      );
 
       client = new ToolboxClient(testBaseUrl);
       await client.loadTool('testTool', {auth: () => 'token'});
@@ -596,7 +594,6 @@ describe('ToolboxClient', () => {
     });
 
     it('should warn in loadToolset with HTTP and auth tokens', async () => {
-      const httpTransport = new MockTransport(httpUrl);
       httpTransport.toolsList.mockResolvedValue({
         serverVersion: '1.0.0',
         tools: {
@@ -607,9 +604,6 @@ describe('ToolboxClient', () => {
           },
         },
       });
-      (McpHttpTransportV20250618 as unknown as jest.Mock).mockImplementation(
-        () => httpTransport,
-      );
 
       client = new ToolboxClient(httpUrl);
       await client.loadToolset('set', {auth: () => 'token'});

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -25,6 +25,8 @@ import {McpHttpTransportV20241105} from '../src/toolbox_core/mcp/v20241105/mcp.j
 import {McpHttpTransportV20250326} from '../src/toolbox_core/mcp/v20250326/mcp.js';
 import {McpHttpTransportV20250618} from '../src/toolbox_core/mcp/v20250618/mcp.js';
 import {McpHttpTransportV20251125} from '../src/toolbox_core/mcp/v20251125/mcp.js';
+import {McpHttpTransportV20260618} from '../src/toolbox_core/mcp/v20260618/mcp.js';
+import {ProtocolNegotiationError} from '../src/toolbox_core/errorUtils.js';
 
 // --- Mock Transport Implementation ---
 class MockTransport implements ITransport {
@@ -73,6 +75,14 @@ jest.mock('../src/toolbox_core/mcp/v20251125/mcp', () => {
   };
 });
 
+// Mock the McpHttpTransportV20260618 module
+jest.mock('../src/toolbox_core/mcp/v20260618/mcp', () => {
+  return {
+    __esModule: true,
+    McpHttpTransportV20260618: jest.fn(),
+  };
+});
+
 describe('ToolboxClient', () => {
   const testBaseUrl = 'https://api.example.com';
   let mockTransport: MockTransport;
@@ -93,6 +103,9 @@ describe('ToolboxClient', () => {
       () => mockTransport,
     );
     (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+      () => mockTransport,
+    );
+    (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
       () => mockTransport,
     );
   });
@@ -603,6 +616,95 @@ describe('ToolboxClient', () => {
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('This connection is using HTTP'),
       );
+    });
+  });
+
+  describe('Protocol Fallback', () => {
+    it('should fall back to supported version in loadTool when transport throws ProtocolNegotiationError', async () => {
+      const draftTransport = new MockTransport(testBaseUrl);
+      const fallbackTransport = new MockTransport(testBaseUrl);
+
+      draftTransport.toolGet.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      fallbackTransport.toolGet.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {
+          testTool: {
+            description: 'desc',
+            parameters: [],
+          },
+        },
+      });
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return draftTransport;
+        },
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return fallbackTransport;
+        },
+      );
+
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      const tool = await client.loadTool('testTool');
+      expect(tool.getName()).toBe('testTool');
+      expect(draftTransport.toolGet).toHaveBeenCalledTimes(1);
+      expect(fallbackTransport.toolGet).toHaveBeenCalledTimes(1);
+      expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to supported version in loadToolset when transport throws ProtocolNegotiationError', async () => {
+      const draftTransport = new MockTransport(testBaseUrl);
+      const fallbackTransport = new MockTransport(testBaseUrl);
+
+      draftTransport.toolsList.mockRejectedValueOnce(
+        new ProtocolNegotiationError(Protocol.MCP_v20251125),
+      );
+
+      fallbackTransport.toolsList.mockResolvedValueOnce({
+        serverVersion: '1.0.0',
+        tools: {
+          testTool: {
+            description: 'desc',
+            parameters: [],
+          },
+        },
+      });
+
+      (McpHttpTransportV20260618 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return draftTransport;
+        },
+      );
+      (McpHttpTransportV20251125 as unknown as jest.Mock).mockImplementation(
+        () => {
+          return fallbackTransport;
+        },
+      );
+
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+
+      const tools = await client.loadToolset('set');
+      expect(tools.length).toBe(1);
+      expect(tools[0].getName()).toBe('testTool');
+      expect(draftTransport.toolsList).toHaveBeenCalledTimes(1);
+      expect(fallbackTransport.toolsList).toHaveBeenCalledTimes(1);
+      expect(McpHttpTransportV20251125).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/toolbox-core/test/test.client.ts
+++ b/packages/toolbox-core/test/test.client.ts
@@ -114,10 +114,10 @@ describe('ToolboxClient', () => {
   describe('Initialization', () => {
     it('should initialize with the correct base URL (default MCP)', () => {
       client = new ToolboxClient(testBaseUrl);
-      expect(McpHttpTransportV20250618).toHaveBeenCalledWith(
+      expect(McpHttpTransportV20251125).toHaveBeenCalledWith(
         testBaseUrl,
         undefined,
-        Protocol.MCP_v20250618,
+        Protocol.MCP_v20251125,
         undefined,
         undefined,
       );
@@ -128,10 +128,10 @@ describe('ToolboxClient', () => {
         get: jest.fn(),
       } as unknown as import('axios').AxiosInstance;
       client = new ToolboxClient(testBaseUrl, mockSession);
-      expect(McpHttpTransportV20250618).toHaveBeenCalledWith(
+      expect(McpHttpTransportV20251125).toHaveBeenCalledWith(
         testBaseUrl,
         mockSession,
-        Protocol.MCP_v20250618,
+        Protocol.MCP_v20251125,
         undefined,
         undefined,
       );
@@ -144,10 +144,10 @@ describe('ToolboxClient', () => {
         undefined,
         Protocol.MCP,
       );
-      expect(McpHttpTransportV20250618).toHaveBeenCalledWith(
+      expect(McpHttpTransportV20251125).toHaveBeenCalledWith(
         testBaseUrl,
         undefined,
-        Protocol.MCP_v20250618,
+        Protocol.MCP_v20251125,
         undefined,
         undefined,
       );
@@ -185,6 +185,22 @@ describe('ToolboxClient', () => {
       );
     });
 
+    it('should initialize with MCP v20250618 transport when specified', () => {
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_v20250618,
+      );
+      expect(McpHttpTransportV20250618).toHaveBeenCalledWith(
+        testBaseUrl,
+        undefined,
+        Protocol.MCP_v20250618,
+        undefined,
+        undefined,
+      );
+    });
+
     it('should initialize with MCP v20251125 transport when specified', () => {
       client = new ToolboxClient(
         testBaseUrl,
@@ -196,6 +212,38 @@ describe('ToolboxClient', () => {
         testBaseUrl,
         undefined,
         Protocol.MCP_v20251125,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should initialize with MCP DRAFT 2026 v1 transport when specified', () => {
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+      );
+      expect(McpHttpTransportV20260618).toHaveBeenCalledWith(
+        testBaseUrl,
+        undefined,
+        Protocol.MCP_DRAFT_2026_v1,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should initialize with MCP DRAFT alias transport when specified', () => {
+      client = new ToolboxClient(
+        testBaseUrl,
+        undefined,
+        undefined,
+        Protocol.MCP_DRAFT,
+      );
+      expect(McpHttpTransportV20260618).toHaveBeenCalledWith(
+        testBaseUrl,
+        undefined,
+        Protocol.MCP_DRAFT,
         undefined,
         undefined,
       );

--- a/packages/toolbox-core/test/test.tool.ts
+++ b/packages/toolbox-core/test/test.tool.ts
@@ -15,12 +15,14 @@
 import {ToolboxTool} from '../src/toolbox_core/tool.js';
 import {z, ZodObject, ZodRawShape} from 'zod';
 import {ITransport} from '../src/toolbox_core/transport.types.js';
+import {Protocol} from '../src/toolbox_core/protocol.js';
 import * as utils from '../src/toolbox_core/utils.js';
 import {ClientHeadersConfig} from '../src/toolbox_core/client.js';
 
 // --- Mock Transport Implementation ---
 class MockTransport implements ITransport {
   readonly baseUrl: string;
+  protocolVersion = Protocol.MCP;
   toolGet: jest.MockedFunction<ITransport['toolGet']>;
   toolsList: jest.MockedFunction<ITransport['toolsList']>;
   toolInvoke: jest.MockedFunction<ITransport['toolInvoke']>;

--- a/packages/toolbox-core/test/test.utils.ts
+++ b/packages/toolbox-core/test/test.utils.ts
@@ -15,6 +15,7 @@
 import {
   resolveValue,
   identifyAuthRequirements,
+  warnIfHttpAndHeaders,
 } from '../src/toolbox_core/utils';
 
 describe('resolveValue', () => {
@@ -211,5 +212,47 @@ describe('identifyAuthRequirements', () => {
     expect(remainingAuthnParams).toEqual({});
     expect(remainingAuthzTokens).toEqual([]);
     expect(usedServices).toEqual(new Set(['serviceA']));
+  });
+});
+
+describe('warnIfHttpAndHeaders', () => {
+  let consoleSpy: jest.SpiedFunction<typeof console.warn>;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('should log a warning if URL is HTTP and headers are present', () => {
+    warnIfHttpAndHeaders('http://api.example.com', {
+      Authorization: 'Bearer token',
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'This connection is using HTTP. To prevent credential exposure, please ensure all communication is sent over HTTPS.',
+      ),
+    );
+  });
+
+  it('should not log a warning if URL is HTTP but headers are empty', () => {
+    warnIfHttpAndHeaders('http://api.example.com', {});
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not log a warning if URL is HTTP but headers are null/undefined', () => {
+    warnIfHttpAndHeaders('http://api.example.com', null);
+    warnIfHttpAndHeaders('http://api.example.com', undefined);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not log a warning if URL is HTTPS even if headers are present', () => {
+    warnIfHttpAndHeaders('https://api.example.com', {
+      Authorization: 'Bearer token',
+    });
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Overview

This base branch PR consolidates the 2026 MCP protocol spec upgrades and auto-negotiation feature set into `main`. It introduces full support for stateless MCP (SEP-2575), HTTP Transport Routing Headers (SEP-2243), Array-Based Protocol Auto-Negotiation with cascading multi-step fallback, and updates the test harness for dual-server E2E testing.

Merging this combined branch enables seamless backward compatibility between modern client SDKs and legacy stateful (`pre-2026`) or new stateless (`v1.6.0+`) servers without lock-step release requirements.

## Changes

This base PR aggregates 5 feature branch PRs:

1. **[#393](https://github.com/googleapis/mcp-toolbox-sdk-js/pull/393) — Stateless MCP & Reference Support (SEP-2575)**
   * Implemented `v20260618` protocol transport for stateless communication.
   * Added header-based protocol declaration (`DRAFT-2026-v1`) and support for JSON schema `$ref` resolution and error utilities.

2. **[#395](https://github.com/googleapis/mcp-toolbox-sdk-js/pull/395) — HTTP Transport Routing Headers (SEP-2243)**
   * Implemented standard routing headers for HTTP transport in `v20260618` protocol to ensure proper routing across network proxies and middleware.

3. **[#394](https://github.com/googleapis/mcp-toolbox-sdk-js/pull/394) — Protocol Definitions & Lavel Alignment**
   * Updated protocol definitions to map `MCP_DRAFT` to active draft specifications.
   * Established fallback triggers for unsupported protocol error codes (`-32004`).

4. **[#402](https://github.com/googleapis/mcp-toolbox-sdk-js/pull/402) — Array-Based Protocol Auto-Negotiation & Multi-Step Fallback**
   * Added support for passing an array of allowed protocol versions (`Protocol[]`) to `ToolboxClient`.
   * Implemented multi-step/cascading fallback handling in `ToolboxClient.#executeWithFallback` to prevent application crashes during sequential version downgrades.
   * Standardized stateful transport handshake mismatches to throw `ProtocolNegotiationError` for automatic client-side renegotiation.

5. **[#413](https://github.com/googleapis/mcp-toolbox-sdk-js/pull/413) — Dual-Server Integration & E2E Test Suite**
   * Upgraded Jest global setup and teardown test harness to launch both stateful and stateless MCP servers simultaneously.
   * Verified protocol fallback behavior and tool execution against dual-server environments.


> [!NOTE]
> This PR is analogous to Python SDK's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/699.