### PR TITLE
fix(core): preserve query parameters in connection URLs for toolset binding

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -64,7 +64,16 @@ export abstract class McpHttpTransportBase implements ITransport {
     clientName?: string,
     clientVersion?: string,
   ) {
-    this._mcpBaseUrl = `${baseUrl}/mcp/`;
+    const parsed = new URL(baseUrl);
+    let path = parsed.pathname;
+    if (path.endsWith('/mcp')) {
+      path += '/';
+    } else if (!path.includes('/mcp/')) {
+      path = path.replace(/\/+$/, '') + '/mcp/';
+    }
+    parsed.pathname = path;
+    this._mcpBaseUrl = parsed.toString();
+
     this._protocolVersion = protocol;
     this._clientName = clientName;
     this._clientVersion = clientVersion;
@@ -88,6 +97,15 @@ export abstract class McpHttpTransportBase implements ITransport {
 
   get baseUrl(): string {
     return this._mcpBaseUrl;
+  }
+
+  protected appendToolsetPath(toolsetName?: string): string {
+    if (!toolsetName) {
+      return this._mcpBaseUrl;
+    }
+    const parsed = new URL(this._mcpBaseUrl);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') + '/' + toolsetName;
+    return parsed.toString();
   }
 
   protected convertToolSchema(toolData: unknown): {

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
@@ -160,7 +160,7 @@ export class McpHttpTransportV20241105 extends McpHttpTransportBase {
     headers?: Record<string, string>,
   ): Promise<ZodManifest> {
     await this.ensureInitialized(headers);
-    const url = `${this._mcpBaseUrl}${toolsetName || ''}`;
+    const url = this.appendToolsetPath(toolsetName);
 
     const result = await this.#sendRequest(
       url,

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
@@ -190,7 +190,7 @@ export class McpHttpTransportV20250326 extends McpHttpTransportBase {
     headers?: Record<string, string>,
   ): Promise<ZodManifest> {
     await this.ensureInitialized(headers);
-    const url = `${this._mcpBaseUrl}${toolsetName || ''}`;
+    const url = this.appendToolsetPath(toolsetName);
 
     const result = await this.#sendRequest(
       url,

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -249,7 +249,7 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
     headers?: Record<string, string>,
   ): Promise<ZodManifest> {
     await this.ensureInitialized(headers);
-    const url = `${this._mcpBaseUrl}${toolsetName || ''}`;
+    const url = this.appendToolsetPath(toolsetName);
 
     const result = await this.#sendRequest(
       url,

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
@@ -249,7 +249,7 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     headers?: Record<string, string>,
   ): Promise<ZodManifest> {
     await this.ensureInitialized(headers);
-    const url = `${this._mcpBaseUrl}${toolsetName || ''}`;
+    const url = this.appendToolsetPath(toolsetName);
 
     const result = await this.#sendRequest(
       url,

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
@@ -241,7 +241,7 @@ export class McpHttpTransportV20260728 extends McpHttpTransportBase {
     headers?: Record<string, string>,
   ): Promise<ZodManifest> {
     await this.ensureInitialized(headers);
-    const url = `${this._mcpBaseUrl}${toolsetName || ''}`;
+    const url = this.appendToolsetPath(toolsetName);
 
     const result = await this.#sendRequest(
       url,

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -816,5 +816,18 @@ testBaseUrls.forEach(testBaseUrl => {
         }
       }
     });
+
+    it('should support URL parameter binding natively when query parameters are in base URL', async () => {
+      const urlWithParams = `${testBaseUrl}?num_rows=2`;
+      const client = new ToolboxClient(urlWithParams);
+
+      const tool = await client.loadTool('get-n-rows');
+      // num_rows is filtered from schema and injected by server via URL query param
+      const response = await tool();
+      expect(typeof response).toBe('string');
+      expect(response).toContain('row1');
+      expect(response).toContain('row2');
+      expect(response).not.toContain('row3');
+    });
   });
 });

--- a/packages/toolbox-core/test/mcp/test.base.ts
+++ b/packages/toolbox-core/test/mcp/test.base.ts
@@ -161,6 +161,44 @@ describe('McpHttpTransportBase', () => {
       expect(transport.getClientName()).toBe('my-client');
       expect(transport.getClientVersion()).toBe('1.2.3');
     });
+
+    const urlTestCases = [
+      {input: 'http://api.com', expected: 'http://api.com/mcp/'},
+      {input: 'http://api.com/', expected: 'http://api.com/mcp/'},
+      {input: 'http://api.com/mcp', expected: 'http://api.com/mcp/'},
+      {input: 'http://api.com/mcp/', expected: 'http://api.com/mcp/'},
+      {
+        input: 'http://api.com?proj=xyz',
+        expected: 'http://api.com/mcp/?proj=xyz',
+      },
+      {
+        input: 'http://api.com/mcp?proj=xyz',
+        expected: 'http://api.com/mcp/?proj=xyz',
+      },
+      {
+        input: 'http://api.com/mcp/?proj=xyz',
+        expected: 'http://api.com/mcp/?proj=xyz',
+      },
+      {
+        input: 'http://api.com/v1/api?proj=xyz',
+        expected: 'http://api.com/v1/api/mcp/?proj=xyz',
+      },
+      {
+        input: 'http://api.com?proj=xyz&env=prod',
+        expected: 'http://api.com/mcp/?proj=xyz&env=prod',
+      },
+      {
+        input: 'http://localhost:5000/mcp/sse?project=my-project',
+        expected: 'http://localhost:5000/mcp/sse?project=my-project',
+      },
+    ];
+
+    urlTestCases.forEach(({input, expected}) => {
+      it(`should construct base URL correctly for ${input}`, () => {
+        const transport = new TestMcpTransport(input);
+        expect(transport.baseUrl).toBe(expected);
+      });
+    });
   });
 
   describe('ensureInitialized', () => {


### PR DESCRIPTION
## Overview

Fixes URL construction when initializing `ToolboxClient` with query parameters (e.g. `http://localhost:5000?num_rows=2` for parameter binding). Previously, naive string template concatenation (`${baseUrl}/mcp/` and `${this._mcpBaseUrl}${toolsetName || ''}`) corrupted base URLs containing query strings (yielding invalid URLs like `http://localhost:5000?num_rows=2/mcp/`).

> [!NOTE]
> This PR is a mirror of Python's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/717.

## Changes

   - Refactored `constructor` using the `URL` API to ensure the `/mcp/` path is inserted before query parameters (e.g. `http://api.com?proj=xyz` ➔ `http://api.com/mcp/?proj=xyz`).
   - Added `protected appendToolsetPath(toolsetName?: string): string` helper method to join toolset path segments while preserving query string parameters.
   - Replaced string template URL concatenation in `toolsList()` with `this.appendToolsetPath(toolsetName)`.
   - Added `urlTestCases` parameterized unit tests in `test.base.ts` to verify base URL construction across URL edge cases.
   - Added `TestRunToolURLBinding` integration test case in `test.e2e.ts` verifying native server-side parameter injection via URL query binding.
