### PR TITLE
feat(core): support response _meta serverInfo and resultType in draft protocol

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
@@ -31,12 +31,13 @@ import {ProtocolNegotiationError} from '../../errorUtils.js';
 
 export class McpHttpTransportV20260728 extends McpHttpTransportBase {
   #getMeta() {
+    const clientInfo: types.Implementation = {
+      name: this._clientName || 'toolbox-core-js',
+      version: this._clientVersion || VERSION,
+    };
     return {
       'io.modelcontextprotocol/protocolVersion': this._protocolVersion,
-      'io.modelcontextprotocol/clientInfo': {
-        name: this._clientName || 'toolbox-core-js',
-        version: this._clientVersion || VERSION,
-      },
+      'io.modelcontextprotocol/clientInfo': clientInfo,
       'io.modelcontextprotocol/clientCapabilities': {},
     };
   }
@@ -232,9 +233,7 @@ export class McpHttpTransportV20260728 extends McpHttpTransportBase {
     // Stateless MCP does not use an initialize handshake.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _headers?: Record<string, string>,
-  ): Promise<void> {
-    this._serverVersion = 'unknown';
-  }
+  ): Promise<void> {}
 
   async toolsList(
     toolsetName?: string,
@@ -269,8 +268,11 @@ export class McpHttpTransportV20260728 extends McpHttpTransportBase {
       toolsMap[tool.name] = this.convertToolSchema(tool);
     }
 
+    const serverVersion =
+      result._meta?.['io.modelcontextprotocol/serverInfo']?.version ?? '0.0.0';
+
     return {
-      serverVersion: this._serverVersion ?? 'unknown',
+      serverVersion,
       tools: toolsMap as unknown as ZodManifest['tools'],
     };
   }

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260728/types.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260728/types.ts
@@ -67,7 +67,27 @@ export const ToolSchema = BaseMetadataSchema.extend({
 
 export type Tool = z.infer<typeof ToolSchema>;
 
-export const ListToolsResultSchema = z.object({
+export const ImplementationSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+});
+export type Implementation = z.infer<typeof ImplementationSchema>;
+
+export const ServerInfoSchema = ImplementationSchema;
+export type ServerInfo = Implementation;
+
+export const MCPResultMetaSchema = z.object({
+  'io.modelcontextprotocol/serverInfo': ServerInfoSchema.optional().nullable(),
+});
+export type MCPResultMeta = z.infer<typeof MCPResultMetaSchema>;
+
+export const MCPResultSchema = z.object({
+  resultType: z.string().default('complete'),
+  _meta: MCPResultMetaSchema.optional().nullable(),
+});
+export type MCPResult = z.infer<typeof MCPResultSchema>;
+
+export const ListToolsResultSchema = MCPResultSchema.extend({
   tools: z.array(ToolSchema),
 });
 export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
@@ -78,7 +98,7 @@ export const TextContentSchema = z.object({
 });
 export type TextContent = z.infer<typeof TextContentSchema>;
 
-export const CallToolResultSchema = z.object({
+export const CallToolResultSchema = MCPResultSchema.extend({
   content: z.array(TextContentSchema),
   isError: z.boolean().default(false).optional(),
 });
@@ -88,7 +108,7 @@ export type CallToolResult = z.infer<typeof CallToolResultSchema>;
 export type MCPRequest<T> = {
   method: string;
   params?: Record<string, unknown> | unknown | null;
-  getResultModel: () => z.ZodType<T>;
+  getResultModel: () => z.ZodType<T, z.ZodTypeDef, unknown>;
 };
 
 export type MCPNotification = {

--- a/packages/toolbox-core/test/mcp/test.v20260728.ts
+++ b/packages/toolbox-core/test/mcp/test.v20260728.ts
@@ -18,6 +18,7 @@ import axios, {AxiosInstance, AxiosError} from 'axios';
 
 import {Protocol} from '../../src/toolbox_core/protocol.js';
 import {ProtocolNegotiationError} from '../../src/toolbox_core/errorUtils.js';
+import * as types from '../../src/toolbox_core/mcp/v20260728/types.js';
 
 jest.mock('axios', () => {
   const actual = jest.requireActual('axios') as {
@@ -808,6 +809,70 @@ describe('McpHttpTransportV20260728', () => {
       );
 
       expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('spec compliance and metadata tests (_meta serverInfo)', () => {
+    it('should extract serverVersion dynamically from _meta serverInfo in toolsList', async () => {
+      const mockResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            resultType: 'complete',
+            tools: [
+              {
+                name: 'sample_tool',
+                description: 'Sample',
+                inputSchema: {type: 'object'},
+              },
+            ],
+            _meta: {
+              'io.modelcontextprotocol/serverInfo': {
+                name: 'ToolboxServer',
+                version: '2.5.0',
+              },
+            },
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(mockResponse);
+
+      const manifest = await transport.toolsList();
+      expect(manifest.serverVersion).toBe('2.5.0');
+      expect(manifest.tools).toHaveProperty('sample_tool');
+    });
+
+    it('should fallback serverVersion to 0.0.0 if _meta or serverInfo is missing', async () => {
+      const mockResponse = {
+        data: {
+          jsonrpc: '2.0',
+          id: '1',
+          result: {
+            resultType: 'complete',
+            tools: [],
+          },
+        },
+        status: 200,
+      };
+
+      mockSession.post.mockResolvedValueOnce(mockResponse);
+
+      const manifest = await transport.toolsList();
+      expect(manifest.serverVersion).toBe('0.0.0');
+    });
+
+    it('should parse resultType correctly and default to complete', () => {
+      const parsedDefault = types.ListToolsResultSchema.parse({tools: []});
+      expect(parsedDefault.resultType).toBe('complete');
+
+      const parsedCustom = types.ListToolsResultSchema.parse({
+        tools: [],
+        resultType: 'input_required',
+      });
+      expect(parsedCustom.resultType).toBe('input_required');
     });
   });
 });


### PR DESCRIPTION
## Overview

Adds support for parsing response `_meta` (`io.modelcontextprotocol/serverInfo`) and `resultType` in the 2026 stateless protocol (`v20260728`).

> [!NOTE]
> This PR is a mirror of Python SDK's https://github.com/googleapis/mcp-toolbox-sdk-python/pull/730.

Previously, `v20260728/mcp.ts` returned `serverVersion: 'unknown'` in `toolsList()`. With this PR, the transport dynamically extracts `serverVersion` from `_meta.['io.modelcontextprotocol/serverInfo'].version` (falling back to `"0.0.0"` if missing).

## Changes
   - Added `ServerInfoSchema` for parsing server name and version.
   - Added `MCPResultMetaSchema` for parsing `io.modelcontextprotocol/serverInfo`.
   - Added `MCPResultSchema` base with `resultType` (optional, default `"complete"`) and `_meta`.
   - Extended `ListToolsResultSchema` and `CallToolResultSchema` from `MCPResultSchema`.
   - Updated `toolsList()` to dynamically extract `serverVersion` from `result._meta?.['io.modelcontextprotocol/serverInfo']?.version ?? '0.0.0'`.
   - Added `spec compliance and metadata tests (_meta serverInfo)` unit test suite in `test.v20260728.ts` verifying:
     - Dynamic `serverVersion` extraction from response `_meta`.
     - Fallback to `'0.0.0'` when `_meta` or `serverInfo` is missing.
     - `resultType` parsing and fallback.