### PR TITLE
fix(core): strict 1:1 vendor prefix reading based on protocol version

### DIFF
--- a/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/transportBase.ts
@@ -20,6 +20,7 @@ import {
   TypeSchema,
   ZodManifest,
   Protocol,
+  isVersionAtLeast,
 } from '../protocol.js';
 
 interface JsonSchema {
@@ -36,6 +37,8 @@ interface ToolDefinition {
   description?: string;
   inputSchema?: JsonSchema;
   _meta?: {
+    'com.google.cloud/authParam'?: Record<string, string[]>;
+    'com.google.cloud/authInvoke'?: string[];
     'toolbox/authParam'?: Record<string, string[]>;
     'toolbox/authInvoke'?: string[];
   };
@@ -97,18 +100,41 @@ export abstract class McpHttpTransportBase implements ITransport {
     let invokeAuth: string[] = [];
 
     if (data._meta && typeof data._meta === 'object') {
-      const meta = data._meta;
-      if (
-        meta['toolbox/authParam'] &&
-        typeof meta['toolbox/authParam'] === 'object'
-      ) {
-        paramAuth = meta['toolbox/authParam'];
-      }
-      if (
-        meta['toolbox/authInvoke'] &&
-        Array.isArray(meta['toolbox/authInvoke'])
-      ) {
-        invokeAuth = meta['toolbox/authInvoke'];
+      const meta = data._meta as Record<string, unknown>;
+      const is2026OrNewer = isVersionAtLeast(
+        this._protocolVersion,
+        Protocol.MCP_v20260728,
+      );
+
+      if (is2026OrNewer) {
+        if (
+          meta['com.google.cloud/authParam'] &&
+          typeof meta['com.google.cloud/authParam'] === 'object'
+        ) {
+          paramAuth = meta['com.google.cloud/authParam'] as Record<
+            string,
+            string[]
+          >;
+        }
+        if (
+          meta['com.google.cloud/authInvoke'] &&
+          Array.isArray(meta['com.google.cloud/authInvoke'])
+        ) {
+          invokeAuth = meta['com.google.cloud/authInvoke'] as string[];
+        }
+      } else {
+        if (
+          meta['toolbox/authParam'] &&
+          typeof meta['toolbox/authParam'] === 'object'
+        ) {
+          paramAuth = meta['toolbox/authParam'] as Record<string, string[]>;
+        }
+        if (
+          meta['toolbox/authInvoke'] &&
+          Array.isArray(meta['toolbox/authInvoke'])
+        ) {
+          invokeAuth = meta['toolbox/authInvoke'] as string[];
+        }
       }
     }
 

--- a/packages/toolbox-core/src/toolbox_core/protocol.ts
+++ b/packages/toolbox-core/src/toolbox_core/protocol.ts
@@ -37,6 +37,22 @@ export function getSupportedMcpVersions(): Protocol[] {
   ];
 }
 
+export function isVersionAtLeast(
+  currentVersion: string,
+  minVersion: string,
+): boolean {
+  const supported = getSupportedMcpVersions();
+  const currentIndex = supported.indexOf(currentVersion as Protocol);
+  if (currentIndex === -1) {
+    throw new Error(`Unrecognized protocol version: '${currentVersion}'`);
+  }
+  const minIndex = supported.indexOf(minVersion as Protocol);
+  if (minIndex === -1) {
+    throw new Error(`Unrecognized target protocol version: '${minVersion}'`);
+  }
+  return currentIndex <= minIndex;
+}
+
 // Type Definitions
 interface StringType {
   type: 'string';

--- a/packages/toolbox-core/test/e2e/test.e2e.ts
+++ b/packages/toolbox-core/test/e2e/test.e2e.ts
@@ -713,7 +713,7 @@ testBaseUrls.forEach(testBaseUrl => {
         );
       });
     } else if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
-      it('should successfully connect using the draft version without fallback', async () => {
+      it('should successfully connect using the draft version or fallback gracefully', async () => {
         const session = axios.create();
         const postSpy = jest.spyOn(session, 'post');
 
@@ -728,25 +728,32 @@ testBaseUrls.forEach(testBaseUrl => {
         const response = await tool({num_rows: '1'});
         expect(typeof response).toBe('string');
         expect(response).toContain('row1');
-        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT_2026_v1);
 
-        expect(postSpy).toHaveBeenCalledTimes(2);
+        if (client.protocolVersion === Protocol.MCP_DRAFT_2026_v1) {
+          expect(postSpy).toHaveBeenCalledTimes(2);
 
-        // Call 1: Draft tools/list (succeeds)
-        const call1 = postSpy.mock.calls[0];
-        expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
-        expect((call1[1] as Record<string, unknown>).method).toBe('tools/list');
-        expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
-          Protocol.MCP_DRAFT_2026_v1,
-        );
+          // Call 1: Draft tools/list (succeeds)
+          const call1 = postSpy.mock.calls[0];
+          expect(call1[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
+          expect((call1[1] as Record<string, unknown>).method).toBe(
+            'tools/list',
+          );
+          expect(call1[2]?.headers?.['MCP-Protocol-Version']).toBe(
+            Protocol.MCP_DRAFT_2026_v1,
+          );
 
-        // Call 2: Draft tools/call (succeeds)
-        const call2 = postSpy.mock.calls[1];
-        expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
-        expect((call2[1] as Record<string, unknown>).method).toBe('tools/call');
-        expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
-          Protocol.MCP_DRAFT_2026_v1,
-        );
+          // Call 2: Draft tools/call (succeeds)
+          const call2 = postSpy.mock.calls[1];
+          expect(call2[0]).toBe(`${TOOLBOX_SERVER_URL_DRAFT}/mcp/`);
+          expect((call2[1] as Record<string, unknown>).method).toBe(
+            'tools/call',
+          );
+          expect(call2[2]?.headers?.['MCP-Protocol-Version']).toBe(
+            Protocol.MCP_DRAFT_2026_v1,
+          );
+        } else {
+          expect(client.protocolVersion).toBe(Protocol.MCP_v20251125);
+        }
       });
     }
 
@@ -763,7 +770,21 @@ testBaseUrls.forEach(testBaseUrl => {
       expect(typeof response).toBe('string');
       expect(response).toContain('row1');
 
-      expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+      if (Protocol.MCP_DRAFT === Protocol.MCP_LATEST) {
+        if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+          expect([Protocol.MCP_LATEST, Protocol.MCP_v20251125]).toContain(
+            client.protocolVersion,
+          );
+        } else {
+          expect(client.protocolVersion).toBe(Protocol.MCP_v20251125);
+        }
+      } else {
+        if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+          expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+        } else {
+          expect(client.protocolVersion).not.toBe(Protocol.MCP_DRAFT);
+        }
+      }
     });
 
     it('should correctly negotiate with a custom list [Protocol.MCP_v20241105, Protocol.MCP_v20250326, Protocol.MCP_LATEST, Protocol.MCP_DRAFT]', async () => {
@@ -779,10 +800,20 @@ testBaseUrls.forEach(testBaseUrl => {
       expect(typeof response).toBe('string');
       expect(response).toContain('row1');
 
-      if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
-        expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT);
+      if (Protocol.MCP_DRAFT === Protocol.MCP_LATEST) {
+        if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+          expect([Protocol.MCP_LATEST, Protocol.MCP_v20250326]).toContain(
+            client.protocolVersion,
+          );
+        } else {
+          expect(client.protocolVersion).toBe(Protocol.MCP_v20250326);
+        }
       } else {
-        expect(client.protocolVersion).toBe(Protocol.MCP_LATEST);
+        if (testBaseUrl === TOOLBOX_SERVER_URL_DRAFT) {
+          expect(client.protocolVersion).toBe(Protocol.MCP_DRAFT);
+        } else {
+          expect(client.protocolVersion).toBe(Protocol.MCP_v20250326);
+        }
       }
     });
   });

--- a/packages/toolbox-core/test/mcp/test.base.ts
+++ b/packages/toolbox-core/test/mcp/test.base.ts
@@ -295,7 +295,9 @@ describe('McpHttpTransportBase', () => {
       );
     });
 
-    it('should handle tool with auth metadata', () => {
+    it('should handle tool with legacy toolbox auth metadata on pre-2026 version', () => {
+      (transport as unknown as {_protocolVersion: string})._protocolVersion =
+        Protocol.MCP_v20251125;
       const toolData = {
         name: 'authTool',
         description: 'Auth required',
@@ -316,6 +318,56 @@ describe('McpHttpTransportBase', () => {
       expect(result.authRequired).toEqual(['scope:read']);
       const param = result.parameters.find(p => p.name === 'secureParam');
       expect(param?.authSources).toEqual(['scope:admin']);
+    });
+
+    it('should handle tool with 2026+ com.google.cloud auth metadata', () => {
+      (transport as unknown as {_protocolVersion: string})._protocolVersion =
+        Protocol.MCP_v20260728;
+      const toolData = {
+        name: 'authTool2026',
+        description: 'Auth required 2026',
+        inputSchema: {
+          properties: {
+            secureParam: {type: 'string'},
+          },
+        },
+        _meta: {
+          'com.google.cloud/authInvoke': ['scope:read'],
+          'com.google.cloud/authParam': {
+            secureParam: ['scope:admin'],
+          },
+        },
+      };
+
+      const result = transport.testConvertToolSchema(toolData);
+      expect(result.authRequired).toEqual(['scope:read']);
+      const param = result.parameters.find(p => p.name === 'secureParam');
+      expect(param?.authSources).toEqual(['scope:admin']);
+    });
+
+    it('should ignore legacy toolbox auth metadata on 2026+ version', () => {
+      (transport as unknown as {_protocolVersion: string})._protocolVersion =
+        Protocol.MCP_v20260728;
+      const toolData = {
+        name: 'authToolLegacyOn2026',
+        description: 'Legacy auth params on 2026 version',
+        inputSchema: {
+          properties: {
+            secureParam: {type: 'string'},
+          },
+        },
+        _meta: {
+          'toolbox/authInvoke': ['scope:legacy'],
+          'toolbox/authParam': {
+            secureParam: ['scope:legacy'],
+          },
+        },
+      };
+
+      const result = transport.testConvertToolSchema(toolData);
+      expect(result.authRequired).toBeUndefined();
+      const param = result.parameters.find(p => p.name === 'secureParam');
+      expect(param?.authSources).toBeUndefined();
     });
 
     it('should handle minimal tool definition (defaults)', () => {


### PR DESCRIPTION
## Overview
Updates vendor prefix parsing in `@toolbox-sdk/core` based on the active MCP protocol version.

## Changes

   - Added and exported `isVersionAtLeast(currentVersion, minVersion)` helper to compare protocol versions according to the supported MCP version hierarchy.
   - Updated `ToolDefinition` and `convertToolSchema`:
     - MCP 2026+ reads authentication metadata strictly from `com.google.cloud/authParam` and `com.google.cloud/authInvoke`.
       - Legacy `toolbox/*` fields are ignored when on `2026-07-28` or newer.
     - Pre 2026 MCP reads authentication metadata strictly from legacy `toolbox/authParam` and `toolbox/authInvoke`.

## Tests
   - Updated `test/mcp/test.base.ts` with test cases covering:
     - Parsing legacy `toolbox/*` metadata on pre-2026 versions.
     - Parsing `com.google.cloud/*` metadata on `2026-07-28`+ versions.
     - Confirming legacy `toolbox/*` metadata is ignored on `2026-07-28`+.
