### PR TITLE
DO NOT MERGE: test update-lockfile push fix

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -44,6 +44,8 @@ jobs:
         run: npm install --package-lock-only --ignore-scripts
 
       - name: Commit and Push changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if package-lock.json changed
           if git diff --quiet package-lock.json; then
@@ -58,4 +60,5 @@ jobs:
           # Commit and push
           git add package-lock.json
           git commit -m "chore: update package-lock.json"
-          git push origin HEAD:${GITHUB_HEAD_REF}
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${GITHUB_HEAD_REF}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15045,7 +15045,7 @@
     },
     "packages/toolbox-core": {
       "name": "@toolbox-sdk/core",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",

--- a/packages/toolbox-core/package.json
+++ b/packages/toolbox-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@toolbox-sdk/core",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "type": "module",
     "description": "JavaScript Base SDK for interacting with the Toolbox service",
     "license": "Apache-2.0",


### PR DESCRIPTION
Throwaway PR to exercise the `Update Lockfile` workflow before the real fix lands. **Do not merge — will be closed and the branch deleted once the run is verified.**

Context: #414's `update-lockfile` job fails at `git push` with `could not read Username for https://github.com`. #400 added `persist-credentials: false` to the checkout but left `git push origin` unchanged, so the remote has no auth.

This branch carries the proposed fix (push to an explicit `x-access-token` URL, the pattern already used in `api-docs-backfill.yml`) plus a core `1.1.0` bump with a deliberately stale lockfile, so the `Commit and Push changes` step actually runs instead of short-circuiting on "no changes".

Success looks like a `chore: update package-lock.json` commit appearing on this branch, pushed by the workflow.
