### PR TITLE
fix(ci): restore lockfile push auth after credential hardening

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -44,6 +44,8 @@ jobs:
         run: npm install --package-lock-only --ignore-scripts
 
       - name: Commit and Push changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if package-lock.json changed
           if git diff --quiet package-lock.json; then
@@ -58,4 +60,5 @@ jobs:
           # Commit and push
           git add package-lock.json
           git commit -m "chore: update package-lock.json"
-          git push origin HEAD:${GITHUB_HEAD_REF}
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${GITHUB_HEAD_REF}"

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -28,7 +28,7 @@ jobs:
     if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The `update-lockfile` job fails at the push step with `could not read Username for https://github.com` — see the failure on #414.

Cause: #400 added `persist-credentials: false` to the checkout as part of the zizmor hardening, but left `git push origin` untouched. With credentials no longer persisted, the `origin` remote has no auth and the push aborts. The commit is created, so the job fails after doing its work.

Fix: push to an explicit `x-access-token` URL, the same pattern `api-docs-backfill.yml` already uses. Hardening is preserved — `persist-credentials: false` stays.
