### PR TITLE
docs: add core and adk v1.1.0 to version dropdown

### DIFF
--- a/docs-site/hugo.toml
+++ b/docs-site/hugo.toml
@@ -14,6 +14,9 @@ title = "MCP Toolbox JS API"
     version = "dev"
     url = "/core/dev/"
   [[params.versions.core]]
+    version = "v1.1.0"
+    url = "/core/v1.1.0/"
+  [[params.versions.core]]
     version = "v1.0.1"
     url = "/core/v1.0.1/"
   [[params.versions.core]]
@@ -28,6 +31,9 @@ title = "MCP Toolbox JS API"
   [[params.versions.adk]]
     version = "dev"
     url = "/adk/dev/"
+  [[params.versions.adk]]
+    version = "v1.1.0"
+    url = "/adk/v1.1.0/"
   [[params.versions.adk]]
     version = "v1.0.0"
     url = "/adk/v1.0.0/"


### PR DESCRIPTION
## Summary
- Pre-register `core` v1.1.0 and `adk` v1.1.0 in `docs-site/hugo.toml` version lists (newest first, just below `dev`) so per-version docs are generated and appear in the navbar version selector when the releases are tagged.
- Aligns with the pending release-please PRs #414 (core 1.1.0) and #415 (adk 1.1.0).