### PR TITLE
chore(deps): bump @toolbox-sdk/core to ^1.1.0 in toolbox-adk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15031,7 +15031,7 @@
         "@google/adk": "^1.0.0",
         "@google/genai": "^2.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@toolbox-sdk/core": "^1.0.0",
+        "@toolbox-sdk/core": "^1.1.0",
         "axios": "^1.16.0",
         "openapi-types": "^12.1.3",
         "zod": "^3.24.4"

--- a/packages/toolbox-adk/package.json
+++ b/packages/toolbox-adk/package.json
@@ -54,7 +54,7 @@
         "@google/adk": "^1.0.0",
         "@google/genai": "^2.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@toolbox-sdk/core": "^1.0.0",
+        "@toolbox-sdk/core": "^1.1.0",
         "axios": "^1.16.0",
         "openapi-types": "^12.1.3",
         "zod": "^3.24.4"


### PR DESCRIPTION
## Description

Bumps the `@toolbox-sdk/core` dependency in `@toolbox-sdk/adk` from `^1.0.0` to `^1.1.0`, following the core 1.1.0 release in #414.