### PR TITLE
chore(deps): drop uuid in favor of node:crypto randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7724,6 +7724,20 @@
         "node": ">=14"
       }
     },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gcp-metadata": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
@@ -13932,6 +13946,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15064,8 +15092,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",
-        "google-auth-library": "^10.0.0",
-        "uuid": "^11.1.0"
+        "google-auth-library": "^10.0.0"
       },
       "devDependencies": {
         "rimraf": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@typescript-eslint/utils": "^8.56.1",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
-    "uuid": "^11.1.1",
     "tmp": "^0.2.7",
     "tar": "^7.5.11",
     "@tootallnate/once": "^3.0.0"

--- a/packages/toolbox-core/package.json
+++ b/packages/toolbox-core/package.json
@@ -59,8 +59,7 @@
     },
     "dependencies": {
         "axios": "^1.16.0",
-        "google-auth-library": "^10.0.0",
-        "uuid": "^11.1.0"
+        "google-auth-library": "^10.0.0"
     },
     "peerDependencies": {
         "zod": "^3.24.4 || ^4.0.0"

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20241105/mcp.ts
@@ -20,7 +20,7 @@ import {ZodManifest, Protocol} from '../../protocol.js';
 import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'node:crypto';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20241105 extends McpHttpTransportBase {
@@ -45,7 +45,7 @@ export class McpHttpTransportV20241105 extends McpHttpTransportBase {
     } else {
       payload = {
         jsonrpc: '2.0',
-        id: uuidv4(),
+        id: randomUUID(),
         method,
         params: params as Record<string, unknown>,
       };

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250326/mcp.ts
@@ -20,7 +20,7 @@ import {ZodManifest, Protocol} from '../../protocol.js';
 import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'node:crypto';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20250326 extends McpHttpTransportBase {
@@ -47,7 +47,7 @@ export class McpHttpTransportV20250326 extends McpHttpTransportBase {
     } else {
       payload = {
         jsonrpc: '2.0',
-        id: uuidv4(),
+        id: randomUUID(),
         method,
         params: params as Record<string, unknown>,
       };

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20250618/mcp.ts
@@ -24,7 +24,7 @@ import {
 import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'node:crypto';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20250618 extends McpHttpTransportBase {
@@ -111,7 +111,7 @@ export class McpHttpTransportV20250618 extends McpHttpTransportBase {
     } else {
       payload = {
         jsonrpc: '2.0',
-        id: uuidv4(),
+        id: randomUUID(),
         method,
         params: params as Record<string, unknown>,
       };

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20251125/mcp.ts
@@ -24,7 +24,7 @@ import {
 import {logApiError, ProtocolNegotiationError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'node:crypto';
 import {VERSION} from '../../version.js';
 
 export class McpHttpTransportV20251125 extends McpHttpTransportBase {
@@ -111,7 +111,7 @@ export class McpHttpTransportV20251125 extends McpHttpTransportBase {
     } else {
       payload = {
         jsonrpc: '2.0',
-        id: uuidv4(),
+        id: randomUUID(),
         method,
         params: params as Record<string, unknown>,
       };

--- a/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
+++ b/packages/toolbox-core/src/toolbox_core/mcp/v20260728/mcp.ts
@@ -24,7 +24,7 @@ import {
 import {logApiError} from '../../errorUtils.js';
 import {warnIfHttpAndHeaders} from '../../utils.js';
 
-import {v4 as uuidv4} from 'uuid';
+import {randomUUID} from 'node:crypto';
 import {VERSION} from '../../version.js';
 
 import {ProtocolNegotiationError} from '../../errorUtils.js';
@@ -125,7 +125,7 @@ export class McpHttpTransportV20260728 extends McpHttpTransportBase {
     } else {
       payload = {
         jsonrpc: '2.0',
-        id: uuidv4(),
+        id: randomUUID(),
         method,
         params: params as Record<string, unknown>,
       };


### PR DESCRIPTION
`uuid` v12+ is ESM-only, so the Renovate bump to v14 (#367) breaks CJS consumers. Rather than bump, drop the dependency: `randomUUID()`
from `node:crypto` produces the same v4 UUIDs we use for JSON-RPC request ids, and we already require `node >=20`.