### PR TITLE
fix(ci): queue pending api-docs deploys instead of dropping them

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -41,7 +41,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,25 +17,30 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main' ]
-    # Only real release tags. '**' also matched the release-please-* tag that
-    # release-please pushes alongside each release; that run built nothing but
-    # still contended for the concurrency slot below, and evicted the version
-    # tag's run. Branch pushes are unaffected -- a push is matched against
-    # `branches` or `tags` depending on its ref type, never both.
-    tags: [ 'core-v*', 'adk-v*' ]
+    # Drop the release-please-* tag that release-please pushes alongside each
+    # release: it resolves to no package and skips every build step, so it is
+    # pure queue and runner overhead. Denylisting it beats listing core-v*/adk-v*
+    # explicitly -- a new package's tags then publish without anyone remembering
+    # to edit this filter. Branch pushes are unaffected: a push is matched
+    # against `branches` or `tags-ignore` by ref type, never both.
+    tags-ignore: [ 'release-please-*' ]
   workflow_dispatch:
 
-# One group, so only one job writes to gh-pages at a time: the deploy action
-# does a plain `git push` with no retry, so concurrent runs would collide.
+# One group, so only one job writes to gh-pages at a time. Two reasons: the
+# deploy action pushes without retrying, and runs share more than their own
+# <pkg>/<version>/ tree -- generate-root.sh rewrites the site root on every tag
+# push, and <pkg>/releases.releases and <pkg>/latest/ are rewritten by both a
+# tag run and every main "dev" run. Serializing keeps that last-writer-wins
+# ordering deterministic.
 #
-# The cost of sharing a group is that GitHub keeps only one *pending* run per
-# group -- a third push cancels the second before it starts. A release now
-# produces two runs (the main merge commit and the version tag), and with two
-# the pending one always survives. Keep it that way: any new trigger that can
-# fire during a release puts release docs back at risk of being dropped.
+# queue: max is what makes sharing a group safe. The default (`single`) holds
+# only one pending run, so a third push cancels the second before it starts --
+# that is how core/adk v1.1.0 were silently dropped. `max` queues up to 100 in
+# FIFO order instead. Requires cancel-in-progress: false.
 concurrency:
   group: api-docs-deploy
   cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:
@@ -81,8 +86,9 @@ jobs:
           # Route the git ref to the package(s) and version to build.
           # A per-package tag builds that one package; pushes to main (and manual
           # dispatch) build both as "dev". JS release tags are hyphenated
-          # (core-vX.Y.Z, adk-vX.Y.Z); the trigger filter admits only those, and
-          # the refs/tags/* catch-all stays as a backstop for anything else.
+          # (core-vX.Y.Z, adk-vX.Y.Z). The trigger only filters out
+          # release-please-*, so any other tag still reaches this step; the
+          # refs/tags/* catch-all resolves it to no package and skips the build.
           REF="${GITHUB_REF}"
           case "$REF" in
             refs/tags/core-v*) echo "packages=core"     >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core-}" >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,11 +17,19 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main' ]
-    tags: [ '**' ]
+    # Only real release tags. Matching '**' also caught release-please-*, which
+    # built nothing but still consumed a slot in the concurrency queue.
+    tags: [ 'core-v*', 'adk-v*' ]
   workflow_dispatch:
 
+# Keyed per ref, so a release-tag run is never queued behind anything and can
+# never be evicted: GitHub holds only one pending run per group, so a third
+# push to a shared group cancels the second before it ever starts. Runs may now
+# overlap, which is safe because the deploy step retries the gh-pages push.
+# Pushes to main still share one group; evicting a superseded "dev" build there
+# is harmless, since the newer run rebuilds from newer main.
 concurrency:
-  group: api-docs-deploy
+  group: api-docs-deploy-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -68,8 +76,8 @@ jobs:
           # Route the git ref to the package(s) and version to build.
           # A per-package tag builds that one package; pushes to main (and manual
           # dispatch) build both as "dev". JS release tags are hyphenated
-          # (core-vX.Y.Z, adk-vX.Y.Z); release-please-* and any other tag are
-          # skipped.
+          # (core-vX.Y.Z, adk-vX.Y.Z); the trigger filter admits only those, and
+          # the catch-all below stays as a backstop for anything unexpected.
           REF="${GITHUB_REF}"
           case "$REF" in
             refs/tags/core-v*) echo "packages=core"     >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core-}" >> "$GITHUB_OUTPUT" ;;
@@ -108,11 +116,47 @@ jobs:
           chmod +x scripts/generate-root.sh
           ./scripts/generate-root.sh "$BASE_URL"
 
+      # Additive publish: each run only writes its own <package>/<version>/
+      # subtree over a fresh checkout of gh-pages, so a run that loses the push
+      # race can simply rebuild on top of the winner and push again. CNAME and
+      # .nojekyll live on the branch and are preserved by the clone.
       - name: Deploy to gh-pages
         if: steps.resolve.outputs.packages != ''
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-site/public
-          keep_files: true 
-          cname: ${{ github.repository == 'googleapis/mcp-toolbox-sdk-js' && 'js.mcp-toolbox.dev' || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          WORK="$(mktemp -d)"
+          git clone --depth 1 --branch gh-pages --single-branch \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$WORK"
+          cd "$WORK"
+
+          for attempt in 1 2 3 4 5; do
+            # Re-apply the build onto the current tip rather than rebasing, so a
+            # concurrent deploy of a different subtree merges cleanly by
+            # construction and can never raise a conflict.
+            git fetch --depth 1 origin gh-pages
+            git reset --hard FETCH_HEAD
+            cp -R "${GITHUB_WORKSPACE}/docs-site/public/." .
+            git add -A
+
+            if git diff --cached --quiet; then
+              echo "No documentation changes for ${GITHUB_REF_NAME}; nothing to deploy."
+              exit 0
+            fi
+
+            git commit -m "docs(api): deploy ${GITHUB_REF_NAME}"
+            if git push origin gh-pages; then
+              echo "Deployed ${GITHUB_REF_NAME} to gh-pages on attempt ${attempt}."
+              exit 0
+            fi
+
+            echo "Push rejected (attempt ${attempt}/5); another deploy landed first. Retrying."
+            sleep $(( attempt * 5 ))
+          done
+
+          echo "::error::Could not push docs to gh-pages after 5 attempts."
+          exit 1

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,26 +17,14 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main' ]
-    # Drop the release-please-* tag that release-please pushes alongside each
-    # release: it resolves to no package and skips every build step, so it is
-    # pure queue and runner overhead. Denylisting it beats listing core-v*/adk-v*
-    # explicitly -- a new package's tags then publish without anyone remembering
-    # to edit this filter. Branch pushes are unaffected: a push is matched
-    # against `branches` or `tags-ignore` by ref type, never both.
+    # release-please pushes this alongside each release; it builds nothing and
+    # only costs a queue slot.
     tags-ignore: [ 'release-please-*' ]
   workflow_dispatch:
 
-# One group, so only one job writes to gh-pages at a time. Two reasons: the
-# deploy action pushes without retrying, and runs share more than their own
-# <pkg>/<version>/ tree -- generate-root.sh rewrites the site root on every tag
-# push, and <pkg>/releases.releases and <pkg>/latest/ are rewritten by both a
-# tag run and every main "dev" run. Serializing keeps that last-writer-wins
-# ordering deterministic.
-#
-# queue: max is what makes sharing a group safe. The default (`single`) holds
-# only one pending run, so a third push cancels the second before it starts --
-# that is how core/adk v1.1.0 were silently dropped. `max` queues up to 100 in
-# FIFO order instead. Requires cancel-in-progress: false.
+# One group: runs share the site root and each package's releases/latest files,
+# and the deploy action pushes without retrying. queue: max holds 100 pending
+# runs; the default of 1 is what silently dropped core/adk v1.1.0.
 concurrency:
   group: api-docs-deploy
   cancel-in-progress: false
@@ -86,9 +74,8 @@ jobs:
           # Route the git ref to the package(s) and version to build.
           # A per-package tag builds that one package; pushes to main (and manual
           # dispatch) build both as "dev". JS release tags are hyphenated
-          # (core-vX.Y.Z, adk-vX.Y.Z). The trigger only filters out
-          # release-please-*, so any other tag still reaches this step; the
-          # refs/tags/* catch-all resolves it to no package and skips the build.
+          # (core-vX.Y.Z, adk-vX.Y.Z); any other tag resolves to no package and
+          # skips the build.
           REF="${GITHUB_REF}"
           case "$REF" in
             refs/tags/core-v*) echo "packages=core"     >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core-}" >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,19 +17,24 @@ name: "API Reference Deployment"
 on:
   push:
     branches: [ 'main' ]
-    # Only real release tags. Matching '**' also caught release-please-*, which
-    # built nothing but still consumed a slot in the concurrency queue.
+    # Only real release tags. '**' also matched the release-please-* tag that
+    # release-please pushes alongside each release; that run built nothing but
+    # still contended for the concurrency slot below, and evicted the version
+    # tag's run. Branch pushes are unaffected -- a push is matched against
+    # `branches` or `tags` depending on its ref type, never both.
     tags: [ 'core-v*', 'adk-v*' ]
   workflow_dispatch:
 
-# Keyed per ref, so a release-tag run is never queued behind anything and can
-# never be evicted: GitHub holds only one pending run per group, so a third
-# push to a shared group cancels the second before it ever starts. Runs may now
-# overlap, which is safe because the deploy step retries the gh-pages push.
-# Pushes to main still share one group; evicting a superseded "dev" build there
-# is harmless, since the newer run rebuilds from newer main.
+# One group, so only one job writes to gh-pages at a time: the deploy action
+# does a plain `git push` with no retry, so concurrent runs would collide.
+#
+# The cost of sharing a group is that GitHub keeps only one *pending* run per
+# group -- a third push cancels the second before it starts. A release now
+# produces two runs (the main merge commit and the version tag), and with two
+# the pending one always survives. Keep it that way: any new trigger that can
+# fire during a release puts release docs back at risk of being dropped.
 concurrency:
-  group: api-docs-deploy-${{ github.ref }}
+  group: api-docs-deploy
   cancel-in-progress: false
 
 jobs:
@@ -77,7 +82,7 @@ jobs:
           # A per-package tag builds that one package; pushes to main (and manual
           # dispatch) build both as "dev". JS release tags are hyphenated
           # (core-vX.Y.Z, adk-vX.Y.Z); the trigger filter admits only those, and
-          # the catch-all below stays as a backstop for anything unexpected.
+          # the refs/tags/* catch-all stays as a backstop for anything else.
           REF="${GITHUB_REF}"
           case "$REF" in
             refs/tags/core-v*) echo "packages=core"     >> "$GITHUB_OUTPUT"; echo "version=${REF#refs/tags/core-}" >> "$GITHUB_OUTPUT" ;;
@@ -116,47 +121,11 @@ jobs:
           chmod +x scripts/generate-root.sh
           ./scripts/generate-root.sh "$BASE_URL"
 
-      # Additive publish: each run only writes its own <package>/<version>/
-      # subtree over a fresh checkout of gh-pages, so a run that loses the push
-      # race can simply rebuild on top of the winner and push again. CNAME and
-      # .nojekyll live on the branch and are preserved by the clone.
       - name: Deploy to gh-pages
         if: steps.resolve.outputs.packages != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          WORK="$(mktemp -d)"
-          git clone --depth 1 --branch gh-pages --single-branch \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$WORK"
-          cd "$WORK"
-
-          for attempt in 1 2 3 4 5; do
-            # Re-apply the build onto the current tip rather than rebasing, so a
-            # concurrent deploy of a different subtree merges cleanly by
-            # construction and can never raise a conflict.
-            git fetch --depth 1 origin gh-pages
-            git reset --hard FETCH_HEAD
-            cp -R "${GITHUB_WORKSPACE}/docs-site/public/." .
-            git add -A
-
-            if git diff --cached --quiet; then
-              echo "No documentation changes for ${GITHUB_REF_NAME}; nothing to deploy."
-              exit 0
-            fi
-
-            git commit -m "docs(api): deploy ${GITHUB_REF_NAME}"
-            if git push origin gh-pages; then
-              echo "Deployed ${GITHUB_REF_NAME} to gh-pages on attempt ${attempt}."
-              exit 0
-            fi
-
-            echo "Push rejected (attempt ${attempt}/5); another deploy landed first. Retrying."
-            sleep $(( attempt * 5 ))
-          done
-
-          echo "::error::Could not push docs to gh-pages after 5 attempts."
-          exit 1
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs-site/public
+          keep_files: true 
+          cname: ${{ github.repository == 'googleapis/mcp-toolbox-sdk-js' && 'js.mcp-toolbox.dev' || '' }}


### PR DESCRIPTION
## Why

`core v1.1.0` and `adk v1.1.0` never published — their deploy runs were **cancelled while queued**, never started.

Release-please pushes three refs within ~10s, all sharing the `api-docs-deploy` group. The default queue holds only **one** pending run, so the third push evicted the version tag ([cancelled run](https://github.com/googleapis/mcp-toolbox-sdk-js/actions/runs/30432769511)). The run that displaced it built nothing and reported success, so this sat behind a green check for four weeks.

## What

- **`queue: max`** — GitHub made queue depth configurable in May 2026. Holds 100 pending runs in FIFO instead of 1, so it scales past two packages rather than depending on few enough refs being pushed at once.
- **Keep the shared group** — runs share the site root and the per-package `releases.releases` / `latest/` files, so serializing keeps last-writer-wins deterministic and the retryless push safe.
- **`tags-ignore: release-please-*`** instead of an allowlist, so a third package publishes without anyone editing the filter.

v1.1.0 itself is restored in #442 / #443.